### PR TITLE
feat: port memory systems with pluggable backend (#7)

### DIFF
--- a/src/felix_agent_sdk/__init__.py
+++ b/src/felix_agent_sdk/__init__.py
@@ -31,6 +31,7 @@ from felix_agent_sdk.providers import (
     auto_detect_provider,
 )
 from felix_agent_sdk.communication import CentralPost, Message, MessageType, Spoke
+from felix_agent_sdk.memory import ContextCompressor, KnowledgeStore, TaskMemory
 from felix_agent_sdk.tokens import TokenBudget
 
 __all__ = [
@@ -56,6 +57,10 @@ __all__ = [
     "Message",
     "MessageType",
     "Spoke",
+    # Memory
+    "KnowledgeStore",
+    "TaskMemory",
+    "ContextCompressor",
     # Tokens
     "TokenBudget",
 ]

--- a/src/felix_agent_sdk/memory/__init__.py
+++ b/src/felix_agent_sdk/memory/__init__.py
@@ -1,9 +1,49 @@
 """Felix memory systems.
 
 Persistent knowledge storage, task pattern recognition, and context compression.
-Planned exports: KnowledgeStore, TaskMemory, ContextCompressor.
-
-Status: Stub — implementation in feat/memory branch.
 """
 
-__all__: list[str] = []
+from felix_agent_sdk.memory.compression import (
+    CompressedContext,
+    CompressionConfig,
+    CompressionLevel,
+    CompressionStrategy,
+    ContextCompressor,
+)
+from felix_agent_sdk.memory.knowledge_store import (
+    ConfidenceLevel,
+    KnowledgeEntry,
+    KnowledgeQuery,
+    KnowledgeStore,
+    KnowledgeType,
+)
+from felix_agent_sdk.memory.task_memory import (
+    TaskComplexity,
+    TaskExecution,
+    TaskMemory,
+    TaskMemoryQuery,
+    TaskOutcome,
+    TaskPattern,
+)
+
+__all__ = [
+    # Knowledge store
+    "KnowledgeStore",
+    "KnowledgeEntry",
+    "KnowledgeQuery",
+    "KnowledgeType",
+    "ConfidenceLevel",
+    # Task memory
+    "TaskMemory",
+    "TaskPattern",
+    "TaskExecution",
+    "TaskMemoryQuery",
+    "TaskOutcome",
+    "TaskComplexity",
+    # Compression
+    "ContextCompressor",
+    "CompressedContext",
+    "CompressionConfig",
+    "CompressionStrategy",
+    "CompressionLevel",
+]

--- a/src/felix_agent_sdk/memory/backends/__init__.py
+++ b/src/felix_agent_sdk/memory/backends/__init__.py
@@ -1,8 +1,9 @@
-"""Pluggable storage backends for Felix memory systems.
+"""Pluggable storage backends for Felix memory systems."""
 
-Planned exports: BaseBackend, SQLiteBackend.
+from felix_agent_sdk.memory.backends.base import BaseBackend
+from felix_agent_sdk.memory.backends.sqlite import SQLiteBackend
 
-Status: Stub — implementation in feat/memory branch.
-"""
-
-__all__: list[str] = []
+__all__ = [
+    "BaseBackend",
+    "SQLiteBackend",
+]

--- a/src/felix_agent_sdk/memory/backends/base.py
+++ b/src/felix_agent_sdk/memory/backends/base.py
@@ -1,0 +1,79 @@
+"""Abstract storage backend for Felix memory systems.
+
+Backends provide typed table-like storage. Each 'table' is identified
+by a string name. Records are dicts with a required 'id' key.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+
+class BaseBackend(ABC):
+    """Abstract base class for memory storage backends.
+
+    Subclasses implement persistence for KnowledgeStore and TaskMemory.
+    The interface is intentionally high-level (CRUD + operators) so that
+    non-SQL backends (Redis, in-memory, cloud) can implement it without
+    SQL translation.
+    """
+
+    # Supported filter operators for query()
+    OPERATORS = ("$gt", "$lt", "$gte", "$lte", "$in", "$contains")
+
+    @abstractmethod
+    def initialize(self, table: str, schema: dict[str, str]) -> None:
+        """Create or verify a table/collection.
+
+        Args:
+            table: Logical table name (e.g. "knowledge_entries").
+            schema: Column name -> type hint mapping. Not enforced at the
+                backend level but used for indexing hints.
+        """
+
+    @abstractmethod
+    def store(self, table: str, record_id: str, data: dict[str, Any]) -> None:
+        """Insert or update (upsert) a record."""
+
+    @abstractmethod
+    def get(self, table: str, record_id: str) -> Optional[dict[str, Any]]:
+        """Retrieve a single record by ID. Returns ``None`` if missing."""
+
+    @abstractmethod
+    def query(
+        self,
+        table: str,
+        filters: Optional[dict[str, Any]] = None,
+        order_by: Optional[str] = None,
+        ascending: bool = True,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Query records matching filters.
+
+        Filters is ``{field: value}`` for exact match, or
+        ``{field: {"$op": value}}`` for operators
+        (``$gt``, ``$lt``, ``$gte``, ``$lte``, ``$in``, ``$contains``).
+        """
+
+    @abstractmethod
+    def delete(self, table: str, record_id: str) -> bool:
+        """Delete a record. Returns ``True`` if it existed."""
+
+    @abstractmethod
+    def count(self, table: str, filters: Optional[dict[str, Any]] = None) -> int:
+        """Count records matching filters."""
+
+    @abstractmethod
+    def search_text(
+        self,
+        table: str,
+        query: str,
+        fields: list[str],
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Full-text search across *fields*. Returns records ranked by relevance."""
+
+    def close(self) -> None:
+        """Release resources. Default is a no-op."""

--- a/src/felix_agent_sdk/memory/backends/sqlite.py
+++ b/src/felix_agent_sdk/memory/backends/sqlite.py
@@ -39,7 +39,9 @@ class SQLiteBackend(BaseBackend):
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA foreign_keys=ON")
         self._fts_tables: set[str] = set()
+        self._fts_text_cols: dict[str, list[str]] = {}
         self._initialized_tables: set[str] = set()
+        self._table_columns: dict[str, set[str]] = {}
 
     # ------------------------------------------------------------------
     # Schema
@@ -67,23 +69,24 @@ class SQLiteBackend(BaseBackend):
                 f"CREATE INDEX IF NOT EXISTS [idx_{table}_{col_name}] ON [{table}]({col_name})"
             )
 
-        # FTS5 virtual table for text search
+        # Standalone FTS5 table for text search (not content-sync)
         text_cols = [c for c, t in schema.items() if t in ("TEXT", "text")]
         if text_cols:
             fts_name = f"{table}_fts"
-            fts_cols = ", ".join(text_cols)
+            fts_col_defs = ", ".join(["record_id"] + text_cols)
             try:
                 self._conn.execute(
                     f"CREATE VIRTUAL TABLE IF NOT EXISTS [{fts_name}] "
-                    f"USING fts5({fts_cols}, content=[{table}], "
-                    f"content_rowid='rowid', tokenize='porter unicode61')"
+                    f"USING fts5({fts_col_defs}, tokenize='porter unicode61')"
                 )
                 self._fts_tables.add(table)
+                self._fts_text_cols[table] = text_cols
             except sqlite3.OperationalError:
                 logger.debug("FTS5 not available; text search will use LIKE")
 
         self._conn.commit()
         self._initialized_tables.add(table)
+        self._table_columns[table] = {"_id"} | set(schema.keys())
 
     # ------------------------------------------------------------------
     # CRUD
@@ -97,6 +100,11 @@ class SQLiteBackend(BaseBackend):
         for key, val in data_copy.items():
             if isinstance(val, (dict, list)):
                 data_copy[key] = json.dumps(val)
+
+        # Filter to only columns that exist in the table
+        valid_cols = self._table_columns.get(table)
+        if valid_cols:
+            data_copy = {k: v for k, v in data_copy.items() if k in valid_cols}
 
         cols = list(data_copy.keys())
         placeholders = ", ".join(["?"] * len(cols))
@@ -125,8 +133,7 @@ class SQLiteBackend(BaseBackend):
         if table in self._fts_tables:
             fts_name = f"{table}_fts"
             self._conn.execute(
-                f"DELETE FROM [{fts_name}] WHERE rowid IN "
-                f"(SELECT rowid FROM [{table}] WHERE _id = ?)",
+                f"DELETE FROM [{fts_name}] WHERE record_id = ?",
                 (record_id,),
             )
 
@@ -238,44 +245,32 @@ class SQLiteBackend(BaseBackend):
         return parts
 
     def _sync_fts(self, table: str, record_id: str, data: dict[str, Any]) -> None:
-        """Sync FTS index after an upsert."""
+        """Sync standalone FTS index after an upsert."""
         fts_name = f"{table}_fts"
-        # Get text columns from FTS schema
-        try:
-            cur = self._conn.execute(f"PRAGMA table_info([{fts_name}])")
-        except sqlite3.OperationalError:
-            return
-        fts_cols = [row[1] for row in cur.fetchall()]
-        if not fts_cols:
+        text_cols = self._fts_text_cols.get(table, [])
+        if not text_cols:
             return
 
         # Delete old FTS row
         self._conn.execute(
-            f"DELETE FROM [{fts_name}] WHERE rowid IN (SELECT rowid FROM [{table}] WHERE _id = ?)",
+            f"DELETE FROM [{fts_name}] WHERE record_id = ?",
             (record_id,),
         )
 
-        # Get rowid
-        cur = self._conn.execute(f"SELECT rowid FROM [{table}] WHERE _id = ?", (record_id,))
-        row = cur.fetchone()
-        if row is None:
-            return
-        rowid = row[0]
-
         # Insert new FTS row
-        vals = [str(data.get(c, "")) for c in fts_cols]
-        placeholders = ", ".join(["?"] * (len(fts_cols) + 1))
-        col_names = ", ".join(["rowid"] + fts_cols)
+        vals = [record_id] + [str(data.get(c, "")) for c in text_cols]
+        col_names = ", ".join(["record_id"] + text_cols)
+        placeholders = ", ".join(["?"] * len(vals))
         self._conn.execute(
             f"INSERT INTO [{fts_name}] ({col_names}) VALUES ({placeholders})",
-            [rowid] + vals,
+            vals,
         )
 
     def _fts_search(self, table: str, query: str, limit: int) -> list[dict[str, Any]]:
         fts_name = f"{table}_fts"
         sql = (
             f"SELECT t.* FROM [{table}] t "
-            f"JOIN [{fts_name}] f ON t.rowid = f.rowid "
+            f"JOIN [{fts_name}] f ON t._id = f.record_id "
             f"WHERE [{fts_name}] MATCH ? "
             f"ORDER BY rank LIMIT ?"
         )
@@ -289,9 +284,14 @@ class SQLiteBackend(BaseBackend):
         fields: list[str],
         limit: int,
     ) -> list[dict[str, Any]]:
-        conditions = [f"{f} LIKE ?" for f in fields]
+        # Filter to columns that actually exist
+        valid = self._table_columns.get(table, set())
+        safe_fields = [f for f in fields if f in valid]
+        if not safe_fields:
+            return []
+        conditions = [f"{f} LIKE ?" for f in safe_fields]
         sql = f"SELECT * FROM [{table}] WHERE " + " OR ".join(conditions) + " LIMIT ?"
-        params = [f"%{query}%"] * len(fields) + [limit]
+        params = [f"%{query}%"] * len(safe_fields) + [limit]
         cur = self._conn.execute(sql, params)
         return [self._row_to_dict(cur.description, row) for row in cur.fetchall()]
 

--- a/src/felix_agent_sdk/memory/backends/sqlite.py
+++ b/src/felix_agent_sdk/memory/backends/sqlite.py
@@ -1,0 +1,313 @@
+"""SQLite storage backend with FTS5 full-text search.
+
+Default backend for Felix memory systems. Uses a single SQLite database
+file (or ``:memory:`` for testing) with dynamic schema initialisation,
+operator-based filter translation, and FTS5 for text search.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from typing import Any, Optional
+
+from felix_agent_sdk.memory.backends.base import BaseBackend
+
+logger = logging.getLogger(__name__)
+
+# Maps operator tokens to SQL comparison operators
+_OP_SQL = {
+    "$gt": ">",
+    "$lt": "<",
+    "$gte": ">=",
+    "$lte": "<=",
+}
+
+
+class SQLiteBackend(BaseBackend):
+    """SQLite-backed storage with FTS5 support.
+
+    Args:
+        db_path: Path to the database file, or ``":memory:"`` for an
+            in-memory database (the default).
+    """
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        self._db_path = db_path
+        self._conn = sqlite3.connect(db_path)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._fts_tables: set[str] = set()
+        self._initialized_tables: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def initialize(self, table: str, schema: dict[str, str]) -> None:
+        if table in self._initialized_tables:
+            return
+
+        # Build column definitions from schema hints
+        col_defs = ["_id TEXT PRIMARY KEY"]
+        for col_name, col_type in schema.items():
+            if col_name == "_id":
+                continue
+            sql_type = self._map_type(col_type)
+            col_defs.append(f"{col_name} {sql_type}")
+
+        self._conn.execute(f"CREATE TABLE IF NOT EXISTS [{table}] ({', '.join(col_defs)})")
+
+        # Create indices on commonly filtered columns
+        for col_name in schema:
+            if col_name == "_id":
+                continue
+            self._conn.execute(
+                f"CREATE INDEX IF NOT EXISTS [idx_{table}_{col_name}] ON [{table}]({col_name})"
+            )
+
+        # FTS5 virtual table for text search
+        text_cols = [c for c, t in schema.items() if t in ("TEXT", "text")]
+        if text_cols:
+            fts_name = f"{table}_fts"
+            fts_cols = ", ".join(text_cols)
+            try:
+                self._conn.execute(
+                    f"CREATE VIRTUAL TABLE IF NOT EXISTS [{fts_name}] "
+                    f"USING fts5({fts_cols}, content=[{table}], "
+                    f"content_rowid='rowid', tokenize='porter unicode61')"
+                )
+                self._fts_tables.add(table)
+            except sqlite3.OperationalError:
+                logger.debug("FTS5 not available; text search will use LIKE")
+
+        self._conn.commit()
+        self._initialized_tables.add(table)
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def store(self, table: str, record_id: str, data: dict[str, Any]) -> None:
+        data_copy = dict(data)
+        data_copy["_id"] = record_id
+
+        # Serialise non-scalar values to JSON
+        for key, val in data_copy.items():
+            if isinstance(val, (dict, list)):
+                data_copy[key] = json.dumps(val)
+
+        cols = list(data_copy.keys())
+        placeholders = ", ".join(["?"] * len(cols))
+        col_names = ", ".join(cols)
+
+        self._conn.execute(
+            f"INSERT OR REPLACE INTO [{table}] ({col_names}) VALUES ({placeholders})",
+            [data_copy[c] for c in cols],
+        )
+
+        # Sync FTS
+        if table in self._fts_tables:
+            self._sync_fts(table, record_id, data_copy)
+
+        self._conn.commit()
+
+    def get(self, table: str, record_id: str) -> Optional[dict[str, Any]]:
+        cur = self._conn.execute(f"SELECT * FROM [{table}] WHERE _id = ?", (record_id,))
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return self._row_to_dict(cur.description, row)
+
+    def delete(self, table: str, record_id: str) -> bool:
+        # Delete FTS entry first
+        if table in self._fts_tables:
+            fts_name = f"{table}_fts"
+            self._conn.execute(
+                f"DELETE FROM [{fts_name}] WHERE rowid IN "
+                f"(SELECT rowid FROM [{table}] WHERE _id = ?)",
+                (record_id,),
+            )
+
+        cur = self._conn.execute(f"DELETE FROM [{table}] WHERE _id = ?", (record_id,))
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def query(
+        self,
+        table: str,
+        filters: Optional[dict[str, Any]] = None,
+        order_by: Optional[str] = None,
+        ascending: bool = True,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        sql = f"SELECT * FROM [{table}]"
+        params: list[Any] = []
+
+        where_parts = self._build_where(filters, params)
+        if where_parts:
+            sql += " WHERE " + " AND ".join(where_parts)
+
+        if order_by:
+            direction = "ASC" if ascending else "DESC"
+            sql += f" ORDER BY {order_by} {direction}"
+
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+            if offset:
+                sql += " OFFSET ?"
+                params.append(offset)
+
+        cur = self._conn.execute(sql, params)
+        return [self._row_to_dict(cur.description, row) for row in cur.fetchall()]
+
+    def count(self, table: str, filters: Optional[dict[str, Any]] = None) -> int:
+        sql = f"SELECT COUNT(*) FROM [{table}]"
+        params: list[Any] = []
+
+        where_parts = self._build_where(filters, params)
+        if where_parts:
+            sql += " WHERE " + " AND ".join(where_parts)
+
+        return self._conn.execute(sql, params).fetchone()[0]
+
+    def search_text(
+        self,
+        table: str,
+        query: str,
+        fields: list[str],
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        if table in self._fts_tables:
+            return self._fts_search(table, query, limit)
+        return self._like_search(table, query, fields, limit)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _map_type(hint: str) -> str:
+        hint_lower = hint.lower()
+        if hint_lower in ("int", "integer", "bool"):
+            return "INTEGER"
+        if hint_lower in ("float", "real", "number"):
+            return "REAL"
+        return "TEXT"
+
+    def _build_where(
+        self,
+        filters: Optional[dict[str, Any]],
+        params: list[Any],
+    ) -> list[str]:
+        if not filters:
+            return []
+
+        parts: list[str] = []
+        for field, value in filters.items():
+            if isinstance(value, dict):
+                # Operator filter: {"$gt": 5}
+                for op, op_val in value.items():
+                    if op == "$in":
+                        placeholders = ", ".join(["?"] * len(op_val))
+                        parts.append(f"{field} IN ({placeholders})")
+                        params.extend(op_val)
+                    elif op == "$contains":
+                        parts.append(f"{field} LIKE ?")
+                        params.append(f"%{op_val}%")
+                    elif op in _OP_SQL:
+                        parts.append(f"{field} {_OP_SQL[op]} ?")
+                        params.append(op_val)
+            else:
+                parts.append(f"{field} = ?")
+                params.append(value)
+        return parts
+
+    def _sync_fts(self, table: str, record_id: str, data: dict[str, Any]) -> None:
+        """Sync FTS index after an upsert."""
+        fts_name = f"{table}_fts"
+        # Get text columns from FTS schema
+        try:
+            cur = self._conn.execute(f"PRAGMA table_info([{fts_name}])")
+        except sqlite3.OperationalError:
+            return
+        fts_cols = [row[1] for row in cur.fetchall()]
+        if not fts_cols:
+            return
+
+        # Delete old FTS row
+        self._conn.execute(
+            f"DELETE FROM [{fts_name}] WHERE rowid IN (SELECT rowid FROM [{table}] WHERE _id = ?)",
+            (record_id,),
+        )
+
+        # Get rowid
+        cur = self._conn.execute(f"SELECT rowid FROM [{table}] WHERE _id = ?", (record_id,))
+        row = cur.fetchone()
+        if row is None:
+            return
+        rowid = row[0]
+
+        # Insert new FTS row
+        vals = [str(data.get(c, "")) for c in fts_cols]
+        placeholders = ", ".join(["?"] * (len(fts_cols) + 1))
+        col_names = ", ".join(["rowid"] + fts_cols)
+        self._conn.execute(
+            f"INSERT INTO [{fts_name}] ({col_names}) VALUES ({placeholders})",
+            [rowid] + vals,
+        )
+
+    def _fts_search(self, table: str, query: str, limit: int) -> list[dict[str, Any]]:
+        fts_name = f"{table}_fts"
+        sql = (
+            f"SELECT t.* FROM [{table}] t "
+            f"JOIN [{fts_name}] f ON t.rowid = f.rowid "
+            f"WHERE [{fts_name}] MATCH ? "
+            f"ORDER BY rank LIMIT ?"
+        )
+        cur = self._conn.execute(sql, (query, limit))
+        return [self._row_to_dict(cur.description, row) for row in cur.fetchall()]
+
+    def _like_search(
+        self,
+        table: str,
+        query: str,
+        fields: list[str],
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        conditions = [f"{f} LIKE ?" for f in fields]
+        sql = f"SELECT * FROM [{table}] WHERE " + " OR ".join(conditions) + " LIMIT ?"
+        params = [f"%{query}%"] * len(fields) + [limit]
+        cur = self._conn.execute(sql, params)
+        return [self._row_to_dict(cur.description, row) for row in cur.fetchall()]
+
+    @staticmethod
+    def _row_to_dict(description: Any, row: tuple[Any, ...]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for i, col_info in enumerate(description):
+            col_name = col_info[0]
+            value = row[i]
+            # Try to deserialise JSON strings
+            if isinstance(value, str):
+                try:
+                    parsed = json.loads(value)
+                    if isinstance(parsed, (dict, list)):
+                        value = parsed
+                except (json.JSONDecodeError, ValueError):
+                    pass
+            result[col_name] = value
+        return result

--- a/src/felix_agent_sdk/memory/compression.py
+++ b/src/felix_agent_sdk/memory/compression.py
@@ -1,0 +1,489 @@
+"""Context compression system for the Felix Agent SDK.
+
+Intelligent summarisation and compression of large contexts through
+extractive, keyword, hierarchical, relevance, and progressive strategies.
+
+Algorithms ported from CalebisGross/felix ``src/memory/context_compression.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+# ------------------------------------------------------------------
+# Enums
+# ------------------------------------------------------------------
+
+
+class CompressionStrategy(Enum):
+    """Available compression strategies."""
+
+    EXTRACTIVE_SUMMARY = "extractive_summary"
+    ABSTRACTIVE_SUMMARY = "abstractive_summary"
+    KEYWORD_EXTRACTION = "keyword_extraction"
+    HIERARCHICAL_SUMMARY = "hierarchical_summary"
+    RELEVANCE_FILTERING = "relevance_filtering"
+    PROGRESSIVE_REFINEMENT = "progressive_refinement"
+
+
+class CompressionLevel(Enum):
+    """Compression intensity levels with retention ratios."""
+
+    LIGHT = "light"  # 80 %
+    MODERATE = "moderate"  # 60 %
+    HEAVY = "heavy"  # 40 %
+    EXTREME = "extreme"  # 20 %
+
+
+RETENTION_RATIOS: dict[CompressionLevel, float] = {
+    CompressionLevel.LIGHT: 0.8,
+    CompressionLevel.MODERATE: 0.6,
+    CompressionLevel.HEAVY: 0.4,
+    CompressionLevel.EXTREME: 0.2,
+}
+
+
+# ------------------------------------------------------------------
+# Data classes
+# ------------------------------------------------------------------
+
+
+@dataclass
+class CompressedContext:
+    """Container for compressed context data."""
+
+    context_id: str
+    original_size: int
+    compressed_size: int
+    compression_ratio: float
+    strategy_used: CompressionStrategy
+    compression_level: CompressionLevel
+    content: dict[str, Any]
+    metadata: dict[str, Any]
+    relevance_scores: dict[str, float]
+    created_at: float = field(default_factory=time.time)
+    access_count: int = 0
+
+    def get_compression_efficiency(self) -> float:
+        """Higher is better (1.0 = full reduction)."""
+        if self.original_size == 0:
+            return 0.0
+        return 1.0 - (self.compressed_size / self.original_size)
+
+
+@dataclass
+class CompressionConfig:
+    """Configuration for context compression."""
+
+    max_context_size: int = 4000
+    strategy: CompressionStrategy = CompressionStrategy.HIERARCHICAL_SUMMARY
+    level: CompressionLevel = CompressionLevel.MODERATE
+    preserve_keywords: list[str] = field(default_factory=list)
+    preserve_structure: bool = True
+    maintain_coherence: bool = True
+    relevance_threshold: float = 0.3
+
+
+# ------------------------------------------------------------------
+# Stopwords (shared with keyword extraction)
+# ------------------------------------------------------------------
+
+_STOPWORDS: set[str] = {
+    "the",
+    "and",
+    "for",
+    "are",
+    "but",
+    "not",
+    "you",
+    "all",
+    "can",
+    "had",
+    "her",
+    "was",
+    "one",
+    "our",
+    "out",
+    "day",
+    "get",
+    "has",
+    "him",
+    "his",
+    "how",
+    "its",
+    "may",
+    "new",
+    "now",
+    "old",
+    "see",
+    "two",
+    "who",
+    "boy",
+    "did",
+    "man",
+    "she",
+    "use",
+    "way",
+    "where",
+    "much",
+    "your",
+    "from",
+    "they",
+    "know",
+    "want",
+    "been",
+    "good",
+    "much",
+    "some",
+    "time",
+    "very",
+    "when",
+    "come",
+    "here",
+    "just",
+    "like",
+    "long",
+    "make",
+    "many",
+    "over",
+    "such",
+    "take",
+    "than",
+    "them",
+    "well",
+    "were",
+    "will",
+    "with",
+}
+
+
+# ------------------------------------------------------------------
+# ContextCompressor
+# ------------------------------------------------------------------
+
+
+class ContextCompressor:
+    """Intelligent context compression with strategy dispatch.
+
+    Args:
+        config: Compression configuration. Uses defaults if ``None``.
+    """
+
+    def __init__(self, config: Optional[CompressionConfig] = None) -> None:
+        self.config = config or CompressionConfig()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def compress_context(
+        self,
+        context: dict[str, Any],
+        target_size: Optional[int] = None,
+        strategy: Optional[CompressionStrategy] = None,
+    ) -> CompressedContext:
+        """Compress *context* using the specified (or default) strategy."""
+        target_size = target_size or self.config.max_context_size
+        strategy = strategy or self.config.strategy
+
+        original_size = len(json.dumps(context))
+
+        dispatch = {
+            CompressionStrategy.EXTRACTIVE_SUMMARY: self._extractive_summary,
+            CompressionStrategy.ABSTRACTIVE_SUMMARY: self._abstractive_summary,
+            CompressionStrategy.KEYWORD_EXTRACTION: self._keyword_extraction,
+            CompressionStrategy.HIERARCHICAL_SUMMARY: self._hierarchical_summary,
+            CompressionStrategy.RELEVANCE_FILTERING: self._relevance_filtering,
+            CompressionStrategy.PROGRESSIVE_REFINEMENT: self._progressive_refinement,
+        }
+
+        handler = dispatch.get(strategy, self._hierarchical_summary)
+        result = handler(context, target_size)
+
+        compressed_size = len(json.dumps(result["content"]))
+        ratio = compressed_size / original_size if original_size > 0 else 0.0
+
+        return CompressedContext(
+            context_id=self._generate_context_id(context),
+            original_size=original_size,
+            compressed_size=compressed_size,
+            compression_ratio=ratio,
+            strategy_used=strategy,
+            compression_level=self.config.level,
+            content=result["content"],
+            metadata=result["metadata"],
+            relevance_scores=result["relevance_scores"],
+        )
+
+    def decompress_context(self, compressed: CompressedContext) -> dict[str, Any]:
+        """Return compressed content with compression metadata attached."""
+        compressed.access_count += 1
+        result = dict(compressed.content)
+        result["_compression_metadata"] = {
+            "original_size": compressed.original_size,
+            "compressed_size": compressed.compressed_size,
+            "compression_ratio": compressed.compression_ratio,
+            "strategy_used": compressed.strategy_used.value,
+            "compression_level": compressed.compression_level.value,
+            "relevance_scores": compressed.relevance_scores,
+        }
+        return result
+
+    def get_compression_stats(self) -> dict[str, Any]:
+        """Return current configuration as stats."""
+        return {
+            "max_context_size": self.config.max_context_size,
+            "default_strategy": self.config.strategy.value,
+            "default_level": self.config.level.value,
+            "preserve_keywords": len(self.config.preserve_keywords),
+            "relevance_threshold": self.config.relevance_threshold,
+        }
+
+    # ------------------------------------------------------------------
+    # Strategies (ported from Felix)
+    # ------------------------------------------------------------------
+
+    def _extractive_summary(self, context: dict[str, Any], target_size: int) -> dict[str, Any]:
+        """Extract most important sentences/sections."""
+        content: dict[str, Any] = {}
+        metadata: dict[str, Any] = {"method": "extractive_summary"}
+        relevance_scores: dict[str, float] = {}
+
+        for key, value in context.items():
+            if isinstance(value, str):
+                sentences = self._split_into_sentences(value)
+                scored = [(s, self._calculate_sentence_importance(s, context)) for s in sentences]
+                for i, (_, score) in enumerate(scored):
+                    relevance_scores[f"{key}_{i}"] = score
+
+                scored.sort(key=lambda x: x[1], reverse=True)
+                target_n = max(1, len(scored) // 3)
+                content[key] = " ".join(s for s, _ in scored[:target_n])
+            else:
+                content[key] = value
+
+        return {"content": content, "metadata": metadata, "relevance_scores": relevance_scores}
+
+    def _abstractive_summary(self, context: dict[str, Any], target_size: int) -> dict[str, Any]:
+        """Abstractive summary — requires an LLM provider (not yet wired).
+
+        Raises :class:`NotImplementedError` so callers know to pick
+        another strategy or integrate a provider.
+        """
+        raise NotImplementedError(
+            "Abstractive summary requires a provider integration; "
+            "use a different CompressionStrategy."
+        )
+
+    def _keyword_extraction(self, context: dict[str, Any], target_size: int) -> dict[str, Any]:
+        """Extract key terms and keyword-rich sentences."""
+        content: dict[str, Any] = {}
+        metadata: dict[str, Any] = {"method": "keyword_extraction"}
+        relevance_scores: dict[str, float] = {}
+
+        all_text = " ".join(str(v) for v in context.values() if isinstance(v, str))
+        keywords = self._extract_keywords(all_text)
+
+        content["keywords"] = keywords[:20]
+        content["key_concepts"] = self._extract_key_concepts(all_text)
+
+        for key, value in context.items():
+            if isinstance(value, str):
+                sentences = self._split_into_sentences(value)
+                keyword_sentences: list[str] = []
+                for sentence in sentences:
+                    count = sum(1 for kw in keywords[:10] if kw.lower() in sentence.lower())
+                    if count > 0:
+                        keyword_sentences.append(sentence)
+                        relevance_scores[f"{key}_sentence"] = count / max(len(keywords[:10]), 1)
+                if keyword_sentences:
+                    content[f"{key}_summary"] = " ".join(keyword_sentences[:3])
+            else:
+                content[key] = value
+
+        return {"content": content, "metadata": metadata, "relevance_scores": relevance_scores}
+
+    def _hierarchical_summary(self, context: dict[str, Any], target_size: int) -> dict[str, Any]:
+        """Three-level summary: core, supporting, auxiliary."""
+        content: dict[str, Any] = {}
+        metadata: dict[str, Any] = {"method": "hierarchical_summary", "levels": 3}
+        relevance_scores: dict[str, float] = {}
+
+        core_keys = {"task", "objective", "requirements", "constraints"}
+        core_info: dict[str, Any] = {}
+        for key, value in context.items():
+            if key in core_keys:
+                core_info[key] = value
+                relevance_scores[f"core_{key}"] = 1.0
+        content["core"] = core_info
+
+        supporting_info: dict[str, Any] = {}
+        for key, value in context.items():
+            if key not in core_info and isinstance(value, str):
+                if len(value) > 100:
+                    supporting_info[key] = self._create_brief_summary(value)
+                    relevance_scores[f"support_{key}"] = 0.7
+                else:
+                    supporting_info[key] = value
+                    relevance_scores[f"support_{key}"] = 0.8
+        content["supporting"] = supporting_info
+
+        auxiliary_info: dict[str, Any] = {}
+        for key, value in context.items():
+            if key not in core_info and key not in supporting_info:
+                auxiliary_info[key] = value
+                relevance_scores[f"aux_{key}"] = 0.5
+        content["auxiliary"] = auxiliary_info
+
+        return {"content": content, "metadata": metadata, "relevance_scores": relevance_scores}
+
+    def _relevance_filtering(self, context: dict[str, Any], target_size: int) -> dict[str, Any]:
+        """Filter content by relevance to main topics."""
+        content: dict[str, Any] = {}
+        metadata: dict[str, Any] = {"method": "relevance_filtering"}
+        relevance_scores: dict[str, float] = {}
+
+        main_topics = self._identify_main_topics(context)
+
+        for key, value in context.items():
+            if isinstance(value, str):
+                relevance = self._calculate_relevance_to_topics(value, main_topics)
+                relevance_scores[key] = relevance
+                if relevance >= self.config.relevance_threshold:
+                    content[key] = value
+                elif relevance >= self.config.relevance_threshold * 0.5:
+                    content[f"{key}_brief"] = self._create_brief_summary(value)
+            else:
+                content[key] = value
+                relevance_scores[key] = 0.8
+
+        return {"content": content, "metadata": metadata, "relevance_scores": relevance_scores}
+
+    def _progressive_refinement(self, context: dict[str, Any], target_size: int) -> dict[str, Any]:
+        """Multiple compression passes for optimal size."""
+        metadata: dict[str, Any] = {"method": "progressive_refinement", "passes": 0}
+        relevance_scores: dict[str, float] = {}
+
+        current = dict(context)
+        passes = 0
+        max_passes = 3
+        strategies = [
+            self._relevance_filtering,
+            self._hierarchical_summary,
+            self._keyword_extraction,
+        ]
+
+        while len(json.dumps(current)) > target_size and passes < max_passes:
+            result = strategies[passes](current, target_size)
+            current = result["content"]
+            relevance_scores.update(result["relevance_scores"])
+            passes += 1
+
+        metadata["passes"] = passes
+        return {"content": current, "metadata": metadata, "relevance_scores": relevance_scores}
+
+    # ------------------------------------------------------------------
+    # Text helpers (ported from Felix)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _generate_context_id(content: dict[str, Any]) -> str:
+        content_str = json.dumps(content, sort_keys=True)
+        hash_input = f"{content_str}:{time.time()}"
+        return hashlib.sha256(hash_input.encode()).hexdigest()[:16]
+
+    @staticmethod
+    def _split_into_sentences(text: str) -> list[str]:
+        sentences = re.split(r"[.!?]+", text)
+        return [s.strip() for s in sentences if s.strip()]
+
+    def _calculate_sentence_importance(self, sentence: str, context: dict[str, Any]) -> float:
+        score = 0.0
+        words = sentence.lower().split()
+
+        # Length bonus
+        if 10 <= len(words) <= 25:
+            score += 0.2
+
+        # Keyword presence
+        for word in words:
+            if word in self.config.preserve_keywords:
+                score += 0.3
+
+        # Numbers / technical terms
+        if any(c.isdigit() for c in sentence):
+            score += 0.1
+        if any(w.isupper() for w in words):
+            score += 0.1
+
+        return score
+
+    def _create_brief_summary(self, text: str) -> str:
+        sentences = self._split_into_sentences(text)
+        if len(sentences) <= 1:
+            return text
+
+        summary = sentences[0]
+        key_info: list[str] = []
+        for sentence in sentences[1:]:
+            numbers = re.findall(r"\b\d+(?:\.\d+)?\b", sentence)
+            key_info.extend(numbers)
+            caps = re.findall(r"\b[A-Z][A-Za-z]*\b", sentence)
+            key_info.extend(caps[:2])
+
+        if key_info:
+            unique = list(set(key_info))[:5]
+            summary += f" Key details: {', '.join(unique)}"
+        return summary
+
+    @staticmethod
+    def _extract_keywords(text: str) -> list[str]:
+        words = re.findall(r"\b\w{4,}\b", text.lower())
+        keywords = [w for w in words if w not in _STOPWORDS]
+        freq: dict[str, int] = {}
+        for w in keywords:
+            freq[w] = freq.get(w, 0) + 1
+        return sorted(freq, key=lambda x: freq[x], reverse=True)[:30]
+
+    @staticmethod
+    def _extract_key_concepts(text: str) -> list[str]:
+        patterns = [
+            r"\b[A-Z]{2,}\b",
+            r"\b\w+[A-Z]\w*\b",
+            r"\b\w+_\w+\b",
+            r"\b\d+\.?\d*[a-zA-Z]+\b",
+        ]
+        concepts: list[str] = []
+        for pat in patterns:
+            concepts.extend(re.findall(pat, text))
+        return list(set(concepts))[:15]
+
+    def _identify_main_topics(self, context: dict[str, Any]) -> list[str]:
+        priority_keys = ("task", "objective", "goal", "purpose", "requirements")
+        topics: list[str] = []
+        for key in priority_keys:
+            if key in context and isinstance(context[key], str):
+                topics.extend(self._extract_keywords(context[key])[:5])
+        if not topics:
+            all_text = " ".join(str(v) for v in context.values() if isinstance(v, str))
+            topics = self._extract_keywords(all_text)[:10]
+        return topics
+
+    @staticmethod
+    def _calculate_relevance_to_topics(text: str, topics: list[str]) -> float:
+        if not topics:
+            return 0.5
+        text_lower = text.lower()
+        matches = sum(1 for t in topics if t.lower() in text_lower)
+        relevance = matches / len(topics)
+        total_mentions = sum(text_lower.count(t.lower()) for t in topics)
+        if total_mentions > matches:
+            relevance += 0.1 * (total_mentions - matches)
+        return min(1.0, relevance)

--- a/src/felix_agent_sdk/memory/knowledge_store.py
+++ b/src/felix_agent_sdk/memory/knowledge_store.py
@@ -96,8 +96,11 @@ class KnowledgeEntry:
     def from_dict(cls, data: dict[str, Any]) -> KnowledgeEntry:
         """Reconstruct from a backend dict."""
         d = dict(data)
-        # Pop backend internal key
-        d.pop("_id", None)
+        # Map backend _id to knowledge_id
+        if "_id" in d:
+            d.setdefault("knowledge_id", d.pop("_id"))
+        else:
+            d.pop("_id", None)
         d["knowledge_type"] = KnowledgeType(d["knowledge_type"])
         d["confidence_level"] = ConfidenceLevel(d["confidence_level"])
         if isinstance(d.get("content"), str):

--- a/src/felix_agent_sdk/memory/knowledge_store.py
+++ b/src/felix_agent_sdk/memory/knowledge_store.py
@@ -244,15 +244,24 @@ class KnowledgeStore:
         self._backend.store(_TABLE, knowledge_id, entry.to_dict())
         return knowledge_id
 
-    def get_entry_by_id(self, knowledge_id: str) -> Optional[KnowledgeEntry]:
-        """Retrieve a single entry by ID."""
+    def get_entry_by_id(
+        self, knowledge_id: str, *, track_access: bool = False
+    ) -> Optional[KnowledgeEntry]:
+        """Retrieve a single entry by ID.
+
+        Args:
+            knowledge_id: Entry ID to look up.
+            track_access: If ``True``, increment the entry's access
+                counter (costs an extra read-modify-write cycle).
+        """
         data = self._backend.get(_TABLE, knowledge_id)
         if data is None:
             return None
         entry = KnowledgeEntry.from_dict(data)
         if entry.is_deleted:
             return None
-        self._increment_access_count(knowledge_id)
+        if track_access:
+            self._increment_access_count(knowledge_id)
         return entry
 
     def update_entry(self, knowledge_id: str, updates: dict[str, Any]) -> bool:

--- a/src/felix_agent_sdk/memory/knowledge_store.py
+++ b/src/felix_agent_sdk/memory/knowledge_store.py
@@ -1,0 +1,466 @@
+"""Knowledge storage system for the Felix Agent SDK.
+
+Persistent storage and retrieval of knowledge entries with confidence tags,
+domain organisation, relationship tracking, and full-text search.
+
+Algorithms ported from CalebisGross/felix ``src/memory/knowledge_store.py``.
+Refactored to use the pluggable :class:`BaseBackend` interface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+from felix_agent_sdk.memory.backends.base import BaseBackend
+from felix_agent_sdk.memory.backends.sqlite import SQLiteBackend
+
+logger = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------
+# Enums
+# ------------------------------------------------------------------
+
+
+class KnowledgeType(Enum):
+    """Types of knowledge that can be stored."""
+
+    TASK_RESULT = "task_result"
+    AGENT_INSIGHT = "agent_insight"
+    PATTERN_RECOGNITION = "pattern_recognition"
+    FAILURE_ANALYSIS = "failure_analysis"
+    OPTIMIZATION_DATA = "optimization_data"
+    DOMAIN_EXPERTISE = "domain_expertise"
+    TOOL_INSTRUCTION = "tool_instruction"
+    FILE_LOCATION = "file_location"
+
+
+class ConfidenceLevel(Enum):
+    """Confidence levels for knowledge entries."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    VERIFIED = "verified"
+
+
+# Numeric ordering for confidence comparisons
+_CONFIDENCE_ORDER: dict[ConfidenceLevel, int] = {
+    ConfidenceLevel.LOW: 0,
+    ConfidenceLevel.MEDIUM: 1,
+    ConfidenceLevel.HIGH: 2,
+    ConfidenceLevel.VERIFIED: 3,
+}
+
+
+# ------------------------------------------------------------------
+# Data classes
+# ------------------------------------------------------------------
+
+
+@dataclass
+class KnowledgeEntry:
+    """Single entry in the knowledge base."""
+
+    knowledge_id: str
+    knowledge_type: KnowledgeType
+    content: dict[str, Any]
+    confidence_level: ConfidenceLevel
+    source_agent: str
+    domain: str
+    tags: list[str] = field(default_factory=list)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    access_count: int = 0
+    success_rate: float = 1.0
+    related_entries: list[str] = field(default_factory=list)
+    is_deleted: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a flat dict suitable for backend storage."""
+        data = asdict(self)
+        data["knowledge_type"] = self.knowledge_type.value
+        data["confidence_level"] = self.confidence_level.value
+        data["content"] = json.dumps(self.content)
+        data["tags"] = json.dumps(self.tags)
+        data["related_entries"] = json.dumps(self.related_entries)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> KnowledgeEntry:
+        """Reconstruct from a backend dict."""
+        d = dict(data)
+        # Pop backend internal key
+        d.pop("_id", None)
+        d["knowledge_type"] = KnowledgeType(d["knowledge_type"])
+        d["confidence_level"] = ConfidenceLevel(d["confidence_level"])
+        if isinstance(d.get("content"), str):
+            d["content"] = json.loads(d["content"])
+        if isinstance(d.get("tags"), str):
+            d["tags"] = json.loads(d["tags"])
+        if isinstance(d.get("related_entries"), str):
+            d["related_entries"] = json.loads(d["related_entries"])
+        if "is_deleted" not in d:
+            d["is_deleted"] = False
+        elif isinstance(d["is_deleted"], int):
+            d["is_deleted"] = bool(d["is_deleted"])
+        return cls(**d)
+
+
+@dataclass
+class KnowledgeQuery:
+    """Query structure for knowledge retrieval."""
+
+    knowledge_types: Optional[list[KnowledgeType]] = None
+    domains: Optional[list[str]] = None
+    tags: Optional[list[str]] = None
+    min_confidence: Optional[ConfidenceLevel] = None
+    min_success_rate: Optional[float] = None
+    content_keywords: Optional[list[str]] = None
+    time_range: Optional[tuple[float, float]] = None
+    search_text: Optional[str] = None
+    limit: int = 100
+
+    def build_filters(self) -> dict[str, Any]:
+        """Translate query fields into backend filter dict."""
+        filters: dict[str, Any] = {"is_deleted": 0}
+
+        if self.knowledge_types:
+            filters["knowledge_type"] = {"$in": [kt.value for kt in self.knowledge_types]}
+        if self.domains:
+            filters["domain"] = {"$in": self.domains}
+        if self.min_confidence is not None:
+            min_level = _CONFIDENCE_ORDER[self.min_confidence]
+            valid = [
+                level.value for level, order in _CONFIDENCE_ORDER.items() if order >= min_level
+            ]
+            filters["confidence_level"] = {"$in": valid}
+        if self.min_success_rate is not None:
+            filters["success_rate"] = {"$gte": self.min_success_rate}
+        if self.time_range:
+            filters["created_at"] = {"$gte": self.time_range[0], "$lte": self.time_range[1]}
+
+        return filters
+
+
+# ------------------------------------------------------------------
+# Schema definitions
+# ------------------------------------------------------------------
+
+_ENTRIES_SCHEMA: dict[str, str] = {
+    "knowledge_type": "TEXT",
+    "content": "TEXT",
+    "confidence_level": "TEXT",
+    "source_agent": "TEXT",
+    "domain": "TEXT",
+    "tags": "TEXT",
+    "created_at": "REAL",
+    "updated_at": "REAL",
+    "access_count": "INTEGER",
+    "success_rate": "REAL",
+    "related_entries": "TEXT",
+    "is_deleted": "INTEGER",
+}
+
+_RELATIONSHIPS_SCHEMA: dict[str, str] = {
+    "source_id": "TEXT",
+    "target_id": "TEXT",
+    "relationship_type": "TEXT",
+    "confidence": "REAL",
+    "created_at": "REAL",
+}
+
+_TABLE = "knowledge_entries"
+_REL_TABLE = "knowledge_relationships"
+
+
+# ------------------------------------------------------------------
+# KnowledgeStore
+# ------------------------------------------------------------------
+
+
+class KnowledgeStore:
+    """Persistent knowledge storage with pluggable backend.
+
+    Args:
+        backend: Storage backend. Defaults to an in-memory
+            :class:`SQLiteBackend` if not supplied.
+    """
+
+    def __init__(self, backend: Optional[BaseBackend] = None) -> None:
+        self._backend = backend or SQLiteBackend()
+        self._backend.initialize(_TABLE, _ENTRIES_SCHEMA)
+        self._backend.initialize(_REL_TABLE, _RELATIONSHIPS_SCHEMA)
+
+    # ------------------------------------------------------------------
+    # ID generation (ported from Felix)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _generate_id(content: dict[str, Any], source_agent: str, domain: str) -> str:
+        content_str = json.dumps(content, sort_keys=True)
+        hash_input = f"{domain}:{content_str}:{source_agent}"
+        return hashlib.sha256(hash_input.encode()).hexdigest()[:16]
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def add_entry(
+        self,
+        knowledge_type: KnowledgeType,
+        content: dict[str, Any],
+        confidence_level: ConfidenceLevel,
+        source_agent: str,
+        domain: str,
+        tags: Optional[list[str]] = None,
+    ) -> str:
+        """Store a new knowledge entry. Returns the knowledge ID."""
+        tags = tags or []
+        knowledge_id = self._generate_id(content, source_agent, domain)
+        now = time.time()
+
+        entry = KnowledgeEntry(
+            knowledge_id=knowledge_id,
+            knowledge_type=knowledge_type,
+            content=content,
+            confidence_level=confidence_level,
+            source_agent=source_agent,
+            domain=domain,
+            tags=tags,
+            created_at=now,
+            updated_at=now,
+        )
+
+        self._backend.store(_TABLE, knowledge_id, entry.to_dict())
+        return knowledge_id
+
+    def get_entry_by_id(self, knowledge_id: str) -> Optional[KnowledgeEntry]:
+        """Retrieve a single entry by ID."""
+        data = self._backend.get(_TABLE, knowledge_id)
+        if data is None:
+            return None
+        entry = KnowledgeEntry.from_dict(data)
+        if entry.is_deleted:
+            return None
+        self._increment_access_count(knowledge_id)
+        return entry
+
+    def update_entry(self, knowledge_id: str, updates: dict[str, Any]) -> bool:
+        """Update fields on an existing entry.
+
+        *updates* may contain: ``content``, ``confidence_level``, ``domain``,
+        ``tags``, ``success_rate``.
+        """
+        data = self._backend.get(_TABLE, knowledge_id)
+        if data is None:
+            return False
+
+        entry = KnowledgeEntry.from_dict(data)
+        if entry.is_deleted:
+            return False
+
+        if "content" in updates:
+            entry.content = updates["content"]
+        if "confidence_level" in updates:
+            level = updates["confidence_level"]
+            entry.confidence_level = (
+                level if isinstance(level, ConfidenceLevel) else ConfidenceLevel(level)
+            )
+        if "domain" in updates:
+            entry.domain = updates["domain"]
+        if "tags" in updates:
+            entry.tags = updates["tags"]
+        if "success_rate" in updates:
+            entry.success_rate = updates["success_rate"]
+
+        entry.updated_at = time.time()
+        self._backend.store(_TABLE, knowledge_id, entry.to_dict())
+        return True
+
+    def delete_entry(self, knowledge_id: str) -> bool:
+        """Soft-delete a knowledge entry."""
+        data = self._backend.get(_TABLE, knowledge_id)
+        if data is None:
+            return False
+        entry = KnowledgeEntry.from_dict(data)
+        entry.is_deleted = True
+        entry.updated_at = time.time()
+        self._backend.store(_TABLE, knowledge_id, entry.to_dict())
+        return True
+
+    def batch_add(
+        self,
+        entries: list[dict[str, Any]],
+    ) -> list[str]:
+        """Add multiple entries. Each dict must contain the fields expected
+        by :meth:`add_entry`. Returns a list of knowledge IDs."""
+        ids: list[str] = []
+        for e in entries:
+            kid = self.add_entry(
+                knowledge_type=e["knowledge_type"],
+                content=e["content"],
+                confidence_level=e["confidence_level"],
+                source_agent=e["source_agent"],
+                domain=e["domain"],
+                tags=e.get("tags"),
+            )
+            ids.append(kid)
+        return ids
+
+    # ------------------------------------------------------------------
+    # Query / search
+    # ------------------------------------------------------------------
+
+    def search(self, query: KnowledgeQuery) -> list[KnowledgeEntry]:
+        """Retrieve entries matching *query*."""
+        if query.search_text:
+            rows = self._backend.search_text(
+                _TABLE,
+                query.search_text,
+                ["content", "domain", "tags"],
+                limit=query.limit,
+            )
+        else:
+            rows = self._backend.query(
+                _TABLE,
+                filters=query.build_filters(),
+                order_by="created_at",
+                ascending=False,
+                limit=query.limit,
+            )
+
+        entries: list[KnowledgeEntry] = []
+        for row in rows:
+            entry = KnowledgeEntry.from_dict(row)
+            if entry.is_deleted:
+                continue
+            # Content-keyword post-filter
+            if query.content_keywords:
+                content_str = json.dumps(entry.content).lower()
+                if not any(kw.lower() in content_str for kw in query.content_keywords):
+                    continue
+            entries.append(entry)
+
+        return entries
+
+    def get_entries_by_type(
+        self, knowledge_type: KnowledgeType, limit: int = 100
+    ) -> list[KnowledgeEntry]:
+        """Retrieve entries of a specific type."""
+        return self.search(KnowledgeQuery(knowledge_types=[knowledge_type], limit=limit))
+
+    def get_entries_by_domain(self, domain: str, limit: int = 100) -> list[KnowledgeEntry]:
+        """Retrieve entries in a specific domain."""
+        return self.search(KnowledgeQuery(domains=[domain], limit=limit))
+
+    def semantic_search(
+        self,
+        query_embedding: list[float],
+        limit: int = 10,
+    ) -> list[KnowledgeEntry]:
+        """Semantic / embedding-based search.
+
+        .. note::
+            Not implemented in the SDK yet. Requires an embedding
+            provider integration (future phase).
+        """
+        raise NotImplementedError(
+            "Semantic search requires an embedding provider; "
+            "use search() with text queries instead."
+        )
+
+    # ------------------------------------------------------------------
+    # Relationships
+    # ------------------------------------------------------------------
+
+    def add_relationship(
+        self,
+        source_id: str,
+        target_id: str,
+        relationship_type: str = "related",
+        confidence: float = 0.7,
+    ) -> bool:
+        """Create a relationship between two entries."""
+        rel_id = hashlib.sha256(
+            f"{source_id}:{target_id}:{relationship_type}".encode()
+        ).hexdigest()[:16]
+
+        self._backend.store(
+            _REL_TABLE,
+            rel_id,
+            {
+                "source_id": source_id,
+                "target_id": target_id,
+                "relationship_type": relationship_type,
+                "confidence": confidence,
+                "created_at": time.time(),
+            },
+        )
+
+        # Also update the related_entries list on the source entry
+        data = self._backend.get(_TABLE, source_id)
+        if data:
+            entry = KnowledgeEntry.from_dict(data)
+            if target_id not in entry.related_entries:
+                entry.related_entries.append(target_id)
+                self._backend.store(_TABLE, source_id, entry.to_dict())
+        return True
+
+    def get_relationships(self, knowledge_id: str) -> list[dict[str, Any]]:
+        """Get all relationships for an entry (bidirectional)."""
+        outgoing = self._backend.query(_REL_TABLE, filters={"source_id": knowledge_id})
+        incoming = self._backend.query(_REL_TABLE, filters={"target_id": knowledge_id})
+        return outgoing + incoming
+
+    # ------------------------------------------------------------------
+    # Success rate
+    # ------------------------------------------------------------------
+
+    def update_success_rate(self, knowledge_id: str, success_rate: float) -> bool:
+        """Update the success rate for a knowledge entry."""
+        return self.update_entry(knowledge_id, {"success_rate": success_rate})
+
+    # ------------------------------------------------------------------
+    # Cleanup / summary
+    # ------------------------------------------------------------------
+
+    def cleanup_old_entries(self, max_age_days: int = 90) -> int:
+        """Hard-delete soft-deleted entries older than *max_age_days*."""
+        cutoff = time.time() - max_age_days * 86400
+        deleted = self._backend.query(
+            _TABLE,
+            filters={"is_deleted": 1, "updated_at": {"$lt": cutoff}},
+        )
+        for row in deleted:
+            self._backend.delete(_TABLE, row["_id"])
+        return len(deleted)
+
+    def get_summary(self) -> dict[str, Any]:
+        """Aggregate statistics about the knowledge store."""
+        total = self._backend.count(_TABLE, filters={"is_deleted": 0})
+        deleted = self._backend.count(_TABLE, filters={"is_deleted": 1})
+        relationships = self._backend.count(_REL_TABLE)
+        return {
+            "total_entries": total,
+            "deleted_entries": deleted,
+            "relationships": relationships,
+        }
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _increment_access_count(self, knowledge_id: str) -> None:
+        data = self._backend.get(_TABLE, knowledge_id)
+        if data is None:
+            return
+        entry = KnowledgeEntry.from_dict(data)
+        entry.access_count += 1
+        self._backend.store(_TABLE, knowledge_id, entry.to_dict())

--- a/src/felix_agent_sdk/memory/task_memory.py
+++ b/src/felix_agent_sdk/memory/task_memory.py
@@ -142,7 +142,10 @@ class TaskPattern:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TaskPattern:
         d = dict(data)
-        d.pop("_id", None)
+        if "_id" in d:
+            d.setdefault("pattern_id", d.pop("_id"))
+        else:
+            d.pop("_id", None)
         d["complexity"] = TaskComplexity(d["complexity"])
         for list_field in ("keywords", "failure_modes", "optimal_strategies", "required_agents"):
             if isinstance(d.get(list_field), str):
@@ -184,7 +187,10 @@ class TaskExecution:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TaskExecution:
         d = dict(data)
-        d.pop("_id", None)
+        if "_id" in d:
+            d.setdefault("execution_id", d.pop("_id"))
+        else:
+            d.pop("_id", None)
         d["complexity"] = TaskComplexity(d["complexity"])
         d["outcome"] = TaskOutcome(d["outcome"])
         for list_field in ("agents_used", "strategies_used", "error_messages", "patterns_matched"):

--- a/src/felix_agent_sdk/memory/task_memory.py
+++ b/src/felix_agent_sdk/memory/task_memory.py
@@ -1,0 +1,600 @@
+"""Task memory system for the Felix Agent SDK.
+
+Pattern recognition, success/failure tracking, and adaptive strategy
+selection based on historical task execution data.
+
+Algorithms ported from CalebisGross/felix ``src/memory/task_memory.py``.
+Refactored to use the pluggable :class:`BaseBackend` interface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+from felix_agent_sdk.memory.backends.base import BaseBackend
+from felix_agent_sdk.memory.backends.sqlite import SQLiteBackend
+
+
+# ------------------------------------------------------------------
+# Enums
+# ------------------------------------------------------------------
+
+
+class TaskOutcome(Enum):
+    """Possible outcomes for task execution."""
+
+    SUCCESS = "success"
+    PARTIAL_SUCCESS = "partial_success"
+    FAILURE = "failure"
+    TIMEOUT = "timeout"
+    ERROR = "error"
+
+
+class TaskComplexity(Enum):
+    """Task complexity levels."""
+
+    SIMPLE = "simple"
+    MODERATE = "moderate"
+    COMPLEX = "complex"
+    VERY_COMPLEX = "very_complex"
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+_STOPWORDS: set[str] = {
+    "the",
+    "and",
+    "for",
+    "are",
+    "but",
+    "not",
+    "you",
+    "all",
+    "can",
+    "had",
+    "her",
+    "was",
+    "one",
+    "our",
+    "out",
+    "day",
+    "get",
+    "has",
+    "him",
+    "his",
+    "how",
+    "its",
+    "may",
+    "new",
+    "now",
+    "old",
+    "see",
+    "two",
+    "who",
+    "boy",
+    "did",
+    "man",
+    "she",
+    "use",
+    "way",
+    "oil",
+    "sit",
+    "set",
+    "run",
+}
+
+
+def _get_enum_value(value: Any) -> str:
+    """Safely get string value from an enum or string."""
+    if isinstance(value, str):
+        return value
+    return getattr(value, "value", str(value))
+
+
+def _extract_keywords(text: str) -> list[str]:
+    """Extract meaningful keywords from *text*."""
+    words = re.findall(r"\b\w{3,}\b", text.lower())
+    keywords = [w for w in words if w not in _STOPWORDS and len(w) > 3]
+    return list(set(keywords))
+
+
+# ------------------------------------------------------------------
+# Data classes
+# ------------------------------------------------------------------
+
+
+@dataclass
+class TaskPattern:
+    """Pattern extracted from task execution history."""
+
+    pattern_id: str
+    task_type: str
+    complexity: TaskComplexity
+    keywords: list[str]
+    typical_duration: float
+    success_rate: float
+    failure_modes: list[str]
+    optimal_strategies: list[str]
+    required_agents: list[str]
+    context_requirements: dict[str, Any]
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    usage_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["complexity"] = _get_enum_value(self.complexity)
+        data["keywords"] = json.dumps(self.keywords)
+        data["failure_modes"] = json.dumps(self.failure_modes)
+        data["optimal_strategies"] = json.dumps(self.optimal_strategies)
+        data["required_agents"] = json.dumps(self.required_agents)
+        data["context_requirements"] = json.dumps(self.context_requirements)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TaskPattern:
+        d = dict(data)
+        d.pop("_id", None)
+        d["complexity"] = TaskComplexity(d["complexity"])
+        for list_field in ("keywords", "failure_modes", "optimal_strategies", "required_agents"):
+            if isinstance(d.get(list_field), str):
+                d[list_field] = json.loads(d[list_field])
+        if isinstance(d.get("context_requirements"), str):
+            d["context_requirements"] = json.loads(d["context_requirements"])
+        return cls(**d)
+
+
+@dataclass
+class TaskExecution:
+    """Record of a single task execution."""
+
+    execution_id: str
+    task_description: str
+    task_type: str
+    complexity: TaskComplexity
+    outcome: TaskOutcome
+    duration: float
+    agents_used: list[str]
+    strategies_used: list[str]
+    context_size: int
+    error_messages: list[str]
+    success_metrics: dict[str, float]
+    patterns_matched: list[str]
+    created_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["complexity"] = _get_enum_value(self.complexity)
+        data["outcome"] = _get_enum_value(self.outcome)
+        data["agents_used"] = json.dumps(self.agents_used)
+        data["strategies_used"] = json.dumps(self.strategies_used)
+        data["error_messages"] = json.dumps(self.error_messages)
+        data["success_metrics"] = json.dumps(self.success_metrics)
+        data["patterns_matched"] = json.dumps(self.patterns_matched)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TaskExecution:
+        d = dict(data)
+        d.pop("_id", None)
+        d["complexity"] = TaskComplexity(d["complexity"])
+        d["outcome"] = TaskOutcome(d["outcome"])
+        for list_field in ("agents_used", "strategies_used", "error_messages", "patterns_matched"):
+            if isinstance(d.get(list_field), str):
+                d[list_field] = json.loads(d[list_field])
+        if isinstance(d.get("success_metrics"), str):
+            d["success_metrics"] = json.loads(d["success_metrics"])
+        return cls(**d)
+
+
+@dataclass
+class TaskMemoryQuery:
+    """Query structure for task memory retrieval."""
+
+    task_types: Optional[list[str]] = None
+    complexity_levels: Optional[list[TaskComplexity]] = None
+    keywords: Optional[list[str]] = None
+    min_success_rate: Optional[float] = None
+    max_duration: Optional[float] = None
+    time_range: Optional[tuple[float, float]] = None
+    limit: int = 10
+
+    def build_filters(self) -> dict[str, Any]:
+        filters: dict[str, Any] = {}
+        if self.task_types:
+            filters["task_type"] = {"$in": self.task_types}
+        if self.complexity_levels:
+            filters["complexity"] = {"$in": [_get_enum_value(c) for c in self.complexity_levels]}
+        if self.min_success_rate is not None:
+            filters["success_rate"] = {"$gte": self.min_success_rate}
+        if self.max_duration is not None:
+            filters["typical_duration"] = {"$lte": self.max_duration}
+        if self.time_range:
+            filters["created_at"] = {"$gte": self.time_range[0], "$lte": self.time_range[1]}
+        return filters
+
+
+# ------------------------------------------------------------------
+# Schema definitions
+# ------------------------------------------------------------------
+
+_PATTERNS_SCHEMA: dict[str, str] = {
+    "task_type": "TEXT",
+    "complexity": "TEXT",
+    "keywords": "TEXT",
+    "typical_duration": "REAL",
+    "success_rate": "REAL",
+    "failure_modes": "TEXT",
+    "optimal_strategies": "TEXT",
+    "required_agents": "TEXT",
+    "context_requirements": "TEXT",
+    "created_at": "REAL",
+    "updated_at": "REAL",
+    "usage_count": "INTEGER",
+}
+
+_EXECUTIONS_SCHEMA: dict[str, str] = {
+    "task_description": "TEXT",
+    "task_type": "TEXT",
+    "complexity": "TEXT",
+    "outcome": "TEXT",
+    "duration": "REAL",
+    "agents_used": "TEXT",
+    "strategies_used": "TEXT",
+    "context_size": "INTEGER",
+    "error_messages": "TEXT",
+    "success_metrics": "TEXT",
+    "patterns_matched": "TEXT",
+    "created_at": "REAL",
+}
+
+_PAT_TABLE = "task_patterns"
+_EXE_TABLE = "task_executions"
+
+
+# ------------------------------------------------------------------
+# TaskMemory
+# ------------------------------------------------------------------
+
+
+class TaskMemory:
+    """Task memory for pattern recognition and adaptive strategy selection.
+
+    Args:
+        backend: Storage backend. Defaults to an in-memory
+            :class:`SQLiteBackend` if not supplied.
+    """
+
+    def __init__(self, backend: Optional[BaseBackend] = None) -> None:
+        self._backend = backend or SQLiteBackend()
+        self._backend.initialize(_PAT_TABLE, _PATTERNS_SCHEMA)
+        self._backend.initialize(_EXE_TABLE, _EXECUTIONS_SCHEMA)
+
+    # ------------------------------------------------------------------
+    # ID generation (ported from Felix)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _generate_execution_id(task_description: str) -> str:
+        hash_input = f"{task_description}:{time.time()}"
+        return hashlib.sha256(hash_input.encode()).hexdigest()[:16]
+
+    @staticmethod
+    def _generate_pattern_id(
+        task_type: str, complexity: TaskComplexity, keywords: list[str]
+    ) -> str:
+        keywords_str = ":".join(sorted(keywords))
+        hash_input = f"{task_type}:{_get_enum_value(complexity)}:{keywords_str}"
+        return hashlib.sha256(hash_input.encode()).hexdigest()[:16]
+
+    # ------------------------------------------------------------------
+    # Record
+    # ------------------------------------------------------------------
+
+    def record_task_execution(
+        self,
+        task_description: str,
+        task_type: str,
+        complexity: TaskComplexity,
+        outcome: TaskOutcome,
+        duration: float,
+        agents_used: list[str],
+        strategies_used: list[str],
+        context_size: int,
+        error_messages: Optional[list[str]] = None,
+        success_metrics: Optional[dict[str, float]] = None,
+    ) -> str:
+        """Record a task execution and update patterns. Returns execution ID."""
+        error_messages = error_messages or []
+        success_metrics = success_metrics or {}
+
+        execution_id = self._generate_execution_id(task_description)
+
+        execution = TaskExecution(
+            execution_id=execution_id,
+            task_description=task_description,
+            task_type=task_type,
+            complexity=complexity,
+            outcome=outcome,
+            duration=duration,
+            agents_used=agents_used,
+            strategies_used=strategies_used,
+            context_size=context_size,
+            error_messages=error_messages,
+            success_metrics=success_metrics,
+            patterns_matched=[],
+        )
+
+        # Find matching patterns
+        matched = self._find_matching_patterns(execution)
+        execution.patterns_matched = [p.pattern_id for p in matched]
+
+        # Store execution
+        self._backend.store(_EXE_TABLE, execution_id, execution.to_dict())
+
+        # Update or create patterns
+        self._update_patterns_from_execution(execution)
+
+        return execution_id
+
+    # ------------------------------------------------------------------
+    # Pattern matching (ported from Felix — 50% keyword overlap)
+    # ------------------------------------------------------------------
+
+    def _find_matching_patterns(self, execution: TaskExecution) -> list[TaskPattern]:
+        query = TaskMemoryQuery(
+            task_types=[execution.task_type],
+            complexity_levels=[execution.complexity],
+        )
+        patterns = self.get_patterns(query)
+        task_keywords = _extract_keywords(execution.task_description)
+
+        matched: list[TaskPattern] = []
+        for pattern in patterns:
+            if not pattern.keywords:
+                continue
+            overlap = len(set(task_keywords) & set(pattern.keywords))
+            if overlap >= len(pattern.keywords) * 0.5:
+                matched.append(pattern)
+        return matched
+
+    def _update_patterns_from_execution(self, execution: TaskExecution) -> None:
+        task_keywords = _extract_keywords(execution.task_description)
+        if not task_keywords:
+            return
+
+        pattern_id = self._generate_pattern_id(
+            execution.task_type, execution.complexity, task_keywords
+        )
+
+        existing = self._get_pattern_by_id(pattern_id)
+        if existing:
+            self._update_existing_pattern(existing, execution)
+        else:
+            self._create_new_pattern(pattern_id, execution, task_keywords)
+
+    def _get_pattern_by_id(self, pattern_id: str) -> Optional[TaskPattern]:
+        data = self._backend.get(_PAT_TABLE, pattern_id)
+        if data is None:
+            return None
+        return TaskPattern.from_dict(data)
+
+    def _update_existing_pattern(self, pattern: TaskPattern, execution: TaskExecution) -> None:
+        """Update existing pattern with new execution data."""
+        executions = self._get_executions_for_pattern(pattern.pattern_id)
+        executions.append(execution)
+
+        # Recalculate success rate
+        successes = sum(
+            1 for e in executions if e.outcome in (TaskOutcome.SUCCESS, TaskOutcome.PARTIAL_SUCCESS)
+        )
+        pattern.success_rate = successes / len(executions)
+
+        # Recalculate typical duration
+        pattern.typical_duration = sum(e.duration for e in executions) / len(executions)
+
+        # Update failure modes
+        failures = [e for e in executions if e.outcome in (TaskOutcome.FAILURE, TaskOutcome.ERROR)]
+        all_failures: list[str] = []
+        for f in failures:
+            all_failures.extend(f.error_messages)
+        pattern.failure_modes = list(set(all_failures))
+
+        # Update optimal strategies (from successful executions)
+        success_execs = [e for e in executions if e.outcome == TaskOutcome.SUCCESS]
+        strategy_counts: dict[str, int] = {}
+        for s in success_execs:
+            for strategy in s.strategies_used:
+                strategy_counts[strategy] = strategy_counts.get(strategy, 0) + 1
+        pattern.optimal_strategies = sorted(
+            strategy_counts, key=lambda x: strategy_counts[x], reverse=True
+        )[:5]
+
+        # Update required agents
+        agent_counts: dict[str, int] = {}
+        for s in success_execs:
+            for agent in s.agents_used:
+                agent_counts[agent] = agent_counts.get(agent, 0) + 1
+        pattern.required_agents = sorted(agent_counts, key=lambda x: agent_counts[x], reverse=True)[
+            :3
+        ]
+
+        pattern.updated_at = time.time()
+        pattern.usage_count += 1
+        self._backend.store(_PAT_TABLE, pattern.pattern_id, pattern.to_dict())
+
+    def _create_new_pattern(
+        self, pattern_id: str, execution: TaskExecution, keywords: list[str]
+    ) -> None:
+        is_success = execution.outcome in (TaskOutcome.SUCCESS, TaskOutcome.PARTIAL_SUCCESS)
+        is_failure = execution.outcome in (TaskOutcome.FAILURE, TaskOutcome.ERROR)
+
+        pattern = TaskPattern(
+            pattern_id=pattern_id,
+            task_type=execution.task_type,
+            complexity=execution.complexity,
+            keywords=keywords,
+            typical_duration=execution.duration,
+            success_rate=1.0 if is_success else 0.0,
+            failure_modes=execution.error_messages if is_failure else [],
+            optimal_strategies=execution.strategies_used
+            if execution.outcome == TaskOutcome.SUCCESS
+            else [],
+            required_agents=execution.agents_used
+            if execution.outcome == TaskOutcome.SUCCESS
+            else [],
+            context_requirements={
+                "min_context_size": execution.context_size,
+                "success_metrics": execution.success_metrics,
+            },
+            usage_count=1,
+        )
+        self._backend.store(_PAT_TABLE, pattern_id, pattern.to_dict())
+
+    def _get_executions_for_pattern(self, pattern_id: str) -> list[TaskExecution]:
+        rows = self._backend.query(
+            _EXE_TABLE,
+            filters={"patterns_matched": {"$contains": pattern_id}},
+        )
+        return [TaskExecution.from_dict(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def get_patterns(self, query: TaskMemoryQuery) -> list[TaskPattern]:
+        """Retrieve task patterns matching *query*."""
+        rows = self._backend.query(
+            _PAT_TABLE,
+            filters=query.build_filters(),
+            order_by="success_rate",
+            ascending=False,
+            limit=query.limit,
+        )
+        patterns: list[TaskPattern] = []
+        for row in rows:
+            pattern = TaskPattern.from_dict(row)
+            # Post-filter by keywords if specified
+            if query.keywords:
+                pattern_kw_lower = [k.lower() for k in pattern.keywords]
+                if not any(kw.lower() in pattern_kw_lower for kw in query.keywords):
+                    continue
+            patterns.append(pattern)
+        return patterns
+
+    # ------------------------------------------------------------------
+    # Strategy recommendation (ported from Felix)
+    # ------------------------------------------------------------------
+
+    def recommend_strategy(
+        self,
+        task_description: str,
+        task_type: str,
+        complexity: TaskComplexity,
+    ) -> dict[str, Any]:
+        """Recommend optimal strategy based on historical patterns."""
+        keywords = _extract_keywords(task_description)
+        query = TaskMemoryQuery(
+            task_types=[task_type],
+            complexity_levels=[complexity],
+            keywords=keywords,
+            min_success_rate=0.5,
+            limit=5,
+        )
+        patterns = self.get_patterns(query)
+
+        if not patterns:
+            return {
+                "strategies": [],
+                "agents": [],
+                "estimated_duration": None,
+                "success_probability": 0.0,
+                "recommendations": "No similar patterns found. Proceeding with default strategy.",
+                "potential_issues": [],
+            }
+
+        all_strategies: list[str] = []
+        all_agents: list[str] = []
+        durations: list[float] = []
+        success_rates: list[float] = []
+        potential_issues: list[str] = []
+
+        for pattern in patterns:
+            all_strategies.extend(pattern.optimal_strategies)
+            all_agents.extend(pattern.required_agents)
+            durations.append(pattern.typical_duration)
+            success_rates.append(pattern.success_rate)
+            potential_issues.extend(pattern.failure_modes)
+
+        # Most common strategies and agents
+        strategy_counts: dict[str, int] = {}
+        for s in all_strategies:
+            strategy_counts[s] = strategy_counts.get(s, 0) + 1
+        agent_counts: dict[str, int] = {}
+        for a in all_agents:
+            agent_counts[a] = agent_counts.get(a, 0) + 1
+
+        recommended_strategies = sorted(
+            strategy_counts, key=lambda x: strategy_counts[x], reverse=True
+        )[:3]
+        recommended_agents = sorted(agent_counts, key=lambda x: agent_counts[x], reverse=True)[:3]
+
+        avg_duration = sum(durations) / len(durations) if durations else None
+        avg_success = sum(success_rates) / len(success_rates) if success_rates else 0.0
+
+        recommendations: list[str] = []
+        if recommended_strategies:
+            recommendations.append(
+                f"Use proven strategies: {', '.join(recommended_strategies[:2])}"
+            )
+        if recommended_agents:
+            recommendations.append(f"Deploy agents: {', '.join(recommended_agents[:2])}")
+        if avg_duration:
+            recommendations.append(f"Expected duration: {avg_duration:.1f} seconds")
+
+        return {
+            "strategies": recommended_strategies,
+            "agents": recommended_agents,
+            "estimated_duration": avg_duration,
+            "success_probability": avg_success,
+            "recommendations": ". ".join(recommendations),
+            "potential_issues": list(set(potential_issues))[:3],
+            "patterns_used": len(patterns),
+        }
+
+    # ------------------------------------------------------------------
+    # Summary / cleanup
+    # ------------------------------------------------------------------
+
+    def get_memory_summary(self) -> dict[str, Any]:
+        """Aggregate statistics about task memory."""
+        total_patterns = self._backend.count(_PAT_TABLE)
+        total_executions = self._backend.count(_EXE_TABLE)
+        return {
+            "total_patterns": total_patterns,
+            "total_executions": total_executions,
+        }
+
+    def cleanup_old_patterns(self, max_age_days: int = 60, min_usage_count: int = 2) -> int:
+        """Remove old or unused patterns."""
+        cutoff = time.time() - max_age_days * 86400
+        old = self._backend.query(
+            _PAT_TABLE,
+            filters={"created_at": {"$lt": cutoff}, "usage_count": {"$lt": min_usage_count}},
+        )
+        zero = self._backend.query(
+            _PAT_TABLE,
+            filters={"success_rate": 0.0, "usage_count": 1},
+        )
+        to_delete = {row["_id"] for row in old} | {row["_id"] for row in zero}
+        for pid in to_delete:
+            self._backend.delete(_PAT_TABLE, pid)
+        return len(to_delete)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,3 +207,53 @@ def spoke_manager(central_post):
     manager = SpokeManager(hub=central_post)
     yield manager
     manager.shutdown_all()
+
+
+# ---------------------------------------------------------------------------
+# Memory fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sqlite_backend(tmp_path):
+    """A fresh SQLiteBackend using a temp directory."""
+    from felix_agent_sdk.memory.backends.sqlite import SQLiteBackend
+
+    db_path = str(tmp_path / "test_memory.db")
+    backend = SQLiteBackend(db_path=db_path)
+    yield backend
+    backend.close()
+
+
+@pytest.fixture
+def memory_backend():
+    """An in-memory SQLiteBackend for fast tests."""
+    from felix_agent_sdk.memory.backends.sqlite import SQLiteBackend
+
+    backend = SQLiteBackend()
+    yield backend
+    backend.close()
+
+
+@pytest.fixture
+def knowledge_store(memory_backend):
+    """A KnowledgeStore with in-memory backend."""
+    from felix_agent_sdk.memory.knowledge_store import KnowledgeStore
+
+    return KnowledgeStore(backend=memory_backend)
+
+
+@pytest.fixture
+def task_memory(memory_backend):
+    """A TaskMemory with in-memory backend."""
+    from felix_agent_sdk.memory.task_memory import TaskMemory
+
+    return TaskMemory(backend=memory_backend)
+
+
+@pytest.fixture
+def compressor():
+    """A default ContextCompressor."""
+    from felix_agent_sdk.memory.compression import ContextCompressor
+
+    return ContextCompressor()

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -1,0 +1,176 @@
+"""Tests for the pluggable backend interface and SQLiteBackend."""
+
+from __future__ import annotations
+
+import pytest
+
+from felix_agent_sdk.memory.backends.base import BaseBackend
+from felix_agent_sdk.memory.backends.sqlite import SQLiteBackend
+
+_SCHEMA = {
+    "name": "TEXT",
+    "value": "REAL",
+    "tags": "TEXT",
+}
+
+
+class TestBaseBackendContract:
+    """Verify that BaseBackend cannot be instantiated directly."""
+
+    def test_abstract(self):
+        with pytest.raises(TypeError):
+            BaseBackend()  # type: ignore[abstract]
+
+
+class TestSQLiteBackendInitialization:
+    def test_in_memory_default(self):
+        backend = SQLiteBackend()
+        backend.initialize("test_table", _SCHEMA)
+        assert backend.count("test_table") == 0
+        backend.close()
+
+    def test_file_backed(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        backend = SQLiteBackend(db_path=db)
+        backend.initialize("t", {"col": "TEXT"})
+        backend.store("t", "1", {"col": "hello"})
+        backend.close()
+
+        # Reopen and verify persistence
+        backend2 = SQLiteBackend(db_path=db)
+        backend2.initialize("t", {"col": "TEXT"})
+        assert backend2.get("t", "1")["col"] == "hello"
+        backend2.close()
+
+    def test_idempotent_init(self, memory_backend):
+        memory_backend.initialize("t", _SCHEMA)
+        memory_backend.initialize("t", _SCHEMA)  # should not raise
+        assert memory_backend.count("t") == 0
+
+
+class TestSQLiteBackendCRUD:
+    def test_store_and_get(self, memory_backend):
+        memory_backend.initialize("t", _SCHEMA)
+        memory_backend.store("t", "r1", {"name": "alpha", "value": 1.0, "tags": "a,b"})
+        row = memory_backend.get("t", "r1")
+        assert row is not None
+        assert row["name"] == "alpha"
+        assert row["value"] == 1.0
+
+    def test_upsert(self, memory_backend):
+        memory_backend.initialize("t", _SCHEMA)
+        memory_backend.store("t", "r1", {"name": "v1", "value": 1.0})
+        memory_backend.store("t", "r1", {"name": "v2", "value": 2.0})
+        row = memory_backend.get("t", "r1")
+        assert row["name"] == "v2"
+        assert memory_backend.count("t") == 1
+
+    def test_get_missing(self, memory_backend):
+        memory_backend.initialize("t", _SCHEMA)
+        assert memory_backend.get("t", "nope") is None
+
+    def test_delete_existing(self, memory_backend):
+        memory_backend.initialize("t", _SCHEMA)
+        memory_backend.store("t", "r1", {"name": "x"})
+        assert memory_backend.delete("t", "r1") is True
+        assert memory_backend.get("t", "r1") is None
+
+    def test_delete_missing(self, memory_backend):
+        memory_backend.initialize("t", _SCHEMA)
+        assert memory_backend.delete("t", "nope") is False
+
+    def test_json_round_trip(self, memory_backend):
+        memory_backend.initialize("t", _SCHEMA)
+        memory_backend.store("t", "r1", {"name": "x", "tags": ["a", "b"]})
+        row = memory_backend.get("t", "r1")
+        assert row["tags"] == ["a", "b"]
+
+
+class TestSQLiteBackendQuery:
+    @pytest.fixture(autouse=True)
+    def _setup(self, memory_backend):
+        self.b = memory_backend
+        self.b.initialize("t", _SCHEMA)
+        self.b.store("t", "1", {"name": "alpha", "value": 1.0})
+        self.b.store("t", "2", {"name": "beta", "value": 2.0})
+        self.b.store("t", "3", {"name": "gamma", "value": 3.0})
+
+    def test_no_filter(self):
+        assert len(self.b.query("t")) == 3
+
+    def test_exact_match(self):
+        rows = self.b.query("t", filters={"name": "beta"})
+        assert len(rows) == 1
+        assert rows[0]["name"] == "beta"
+
+    def test_gt_operator(self):
+        rows = self.b.query("t", filters={"value": {"$gt": 1.5}})
+        assert len(rows) == 2
+
+    def test_lt_operator(self):
+        rows = self.b.query("t", filters={"value": {"$lt": 2.0}})
+        assert len(rows) == 1
+
+    def test_gte_lte_operators(self):
+        rows = self.b.query("t", filters={"value": {"$gte": 2.0, "$lte": 3.0}})
+        assert len(rows) == 2
+
+    def test_in_operator(self):
+        rows = self.b.query("t", filters={"name": {"$in": ["alpha", "gamma"]}})
+        assert len(rows) == 2
+
+    def test_contains_operator(self):
+        rows = self.b.query("t", filters={"name": {"$contains": "eta"}})
+        assert len(rows) == 1
+
+    def test_order_by_asc(self):
+        rows = self.b.query("t", order_by="value", ascending=True)
+        assert [r["value"] for r in rows] == [1.0, 2.0, 3.0]
+
+    def test_order_by_desc(self):
+        rows = self.b.query("t", order_by="value", ascending=False)
+        assert [r["value"] for r in rows] == [3.0, 2.0, 1.0]
+
+    def test_limit_offset(self):
+        rows = self.b.query("t", order_by="value", ascending=True, limit=2, offset=1)
+        assert len(rows) == 2
+        assert rows[0]["value"] == 2.0
+
+    def test_count_with_filter(self):
+        assert self.b.count("t", filters={"value": {"$gt": 1.5}}) == 2
+
+    def test_count_no_filter(self):
+        assert self.b.count("t") == 3
+
+
+class TestSQLiteBackendTextSearch:
+    def test_fts_search(self, memory_backend):
+        memory_backend.initialize("docs", {"title": "TEXT", "body": "TEXT"})
+        memory_backend.store("docs", "1", {"title": "python guide", "body": "learn python programming"})
+        memory_backend.store("docs", "2", {"title": "rust guide", "body": "learn rust systems"})
+        memory_backend.store("docs", "3", {"title": "cooking tips", "body": "how to cook pasta"})
+
+        results = memory_backend.search_text("docs", "python", ["title", "body"])
+        assert len(results) >= 1
+        assert any("python" in str(r.get("title", "")).lower() for r in results)
+
+    def test_like_fallback(self, memory_backend):
+        """LIKE search when no FTS table exists (schema has no TEXT cols marked)."""
+        memory_backend.initialize("nums", {"val": "INTEGER"})
+        # search_text should not crash
+        results = memory_backend.search_text("nums", "hello", ["val"])
+        assert results == []
+
+
+class TestSQLiteBackendClose:
+    def test_close_then_reopen(self, tmp_path):
+        db = str(tmp_path / "close_test.db")
+        b = SQLiteBackend(db_path=db)
+        b.initialize("t", {"x": "TEXT"})
+        b.store("t", "1", {"x": "v"})
+        b.close()
+
+        b2 = SQLiteBackend(db_path=db)
+        b2.initialize("t", {"x": "TEXT"})
+        assert b2.get("t", "1")["x"] == "v"
+        b2.close()

--- a/tests/unit/test_compression.py
+++ b/tests/unit/test_compression.py
@@ -1,0 +1,232 @@
+"""Tests for the ContextCompressor strategies."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from felix_agent_sdk.memory.compression import (
+    CompressedContext,
+    CompressionConfig,
+    CompressionLevel,
+    CompressionStrategy,
+    ContextCompressor,
+    RETENTION_RATIOS,
+)
+
+
+# ------------------------------------------------------------------
+# Enums & data classes
+# ------------------------------------------------------------------
+
+
+class TestCompressionEnums:
+    def test_strategy_values(self):
+        assert CompressionStrategy.EXTRACTIVE_SUMMARY.value == "extractive_summary"
+        assert len(CompressionStrategy) == 6
+
+    def test_level_values(self):
+        assert CompressionLevel.LIGHT.value == "light"
+        assert len(CompressionLevel) == 4
+
+    def test_retention_ratios(self):
+        assert RETENTION_RATIOS[CompressionLevel.LIGHT] == 0.8
+        assert RETENTION_RATIOS[CompressionLevel.MODERATE] == 0.6
+        assert RETENTION_RATIOS[CompressionLevel.HEAVY] == 0.4
+        assert RETENTION_RATIOS[CompressionLevel.EXTREME] == 0.2
+
+
+class TestCompressedContext:
+    def test_efficiency(self):
+        ctx = CompressedContext(
+            context_id="x",
+            original_size=1000,
+            compressed_size=400,
+            compression_ratio=0.4,
+            strategy_used=CompressionStrategy.EXTRACTIVE_SUMMARY,
+            compression_level=CompressionLevel.MODERATE,
+            content={"text": "short"},
+            metadata={},
+            relevance_scores={},
+        )
+        assert abs(ctx.get_compression_efficiency() - 0.6) < 1e-6
+
+    def test_efficiency_zero_original(self):
+        ctx = CompressedContext(
+            context_id="x",
+            original_size=0,
+            compressed_size=0,
+            compression_ratio=0.0,
+            strategy_used=CompressionStrategy.EXTRACTIVE_SUMMARY,
+            compression_level=CompressionLevel.LIGHT,
+            content={},
+            metadata={},
+            relevance_scores={},
+        )
+        assert ctx.get_compression_efficiency() == 0.0
+
+
+# ------------------------------------------------------------------
+# ContextCompressor
+# ------------------------------------------------------------------
+
+_SAMPLE_CONTEXT = {
+    "task": "Analyse the impact of renewable energy on grid stability",
+    "objective": "Determine correlation between solar adoption and outages",
+    "background": (
+        "Renewable energy sources have grown significantly over the past decade. "
+        "Solar and wind power now account for a substantial portion of electricity generation. "
+        "Grid operators must balance supply and demand in real time. "
+        "Battery storage technologies are evolving rapidly to address intermittency."
+    ),
+    "notes": "Check the 2024 NREL report for baseline data.",
+    "count": 42,
+}
+
+
+class TestExtractiveSummary:
+    def test_reduces_text(self, compressor):
+        result = compressor.compress_context(
+            _SAMPLE_CONTEXT,
+            strategy=CompressionStrategy.EXTRACTIVE_SUMMARY,
+        )
+        assert result.compressed_size <= result.original_size
+        assert result.strategy_used == CompressionStrategy.EXTRACTIVE_SUMMARY
+        assert "background" in result.content
+
+    def test_preserves_non_string_values(self, compressor):
+        result = compressor.compress_context(
+            _SAMPLE_CONTEXT,
+            strategy=CompressionStrategy.EXTRACTIVE_SUMMARY,
+        )
+        assert result.content["count"] == 42
+
+
+class TestKeywordExtraction:
+    def test_extracts_keywords(self, compressor):
+        result = compressor.compress_context(
+            _SAMPLE_CONTEXT,
+            strategy=CompressionStrategy.KEYWORD_EXTRACTION,
+        )
+        assert "keywords" in result.content
+        assert isinstance(result.content["keywords"], list)
+        assert len(result.content["keywords"]) > 0
+
+    def test_extracts_concepts(self, compressor):
+        result = compressor.compress_context(
+            {"text": "The NREL report uses CamelCase identifiers and snake_case variables"},
+            strategy=CompressionStrategy.KEYWORD_EXTRACTION,
+        )
+        concepts = result.content.get("key_concepts", [])
+        assert isinstance(concepts, list)
+
+
+class TestHierarchicalSummary:
+    def test_three_levels(self, compressor):
+        result = compressor.compress_context(
+            _SAMPLE_CONTEXT,
+            strategy=CompressionStrategy.HIERARCHICAL_SUMMARY,
+        )
+        assert "core" in result.content
+        assert "supporting" in result.content
+        assert "auxiliary" in result.content
+        assert result.metadata["levels"] == 3
+
+    def test_core_preserves_task_keys(self, compressor):
+        result = compressor.compress_context(
+            _SAMPLE_CONTEXT,
+            strategy=CompressionStrategy.HIERARCHICAL_SUMMARY,
+        )
+        core = result.content["core"]
+        assert "task" in core
+        assert "objective" in core
+
+
+class TestRelevanceFiltering:
+    def test_filters_by_relevance(self, compressor):
+        result = compressor.compress_context(
+            _SAMPLE_CONTEXT,
+            strategy=CompressionStrategy.RELEVANCE_FILTERING,
+        )
+        assert result.strategy_used == CompressionStrategy.RELEVANCE_FILTERING
+        # Non-string values preserved
+        assert result.content.get("count") == 42
+
+
+class TestProgressiveRefinement:
+    def test_multiple_passes(self, compressor):
+        # Use a very small target to force multiple passes
+        result = compressor.compress_context(
+            _SAMPLE_CONTEXT,
+            target_size=50,
+            strategy=CompressionStrategy.PROGRESSIVE_REFINEMENT,
+        )
+        assert result.metadata["method"] == "progressive_refinement"
+        assert result.metadata["passes"] > 0
+
+    def test_no_passes_needed(self, compressor):
+        # Target larger than content = 0 passes
+        result = compressor.compress_context(
+            {"short": "hi"},
+            target_size=100000,
+            strategy=CompressionStrategy.PROGRESSIVE_REFINEMENT,
+        )
+        assert result.metadata["passes"] == 0
+
+
+class TestAbstractiveSummary:
+    def test_not_implemented(self, compressor):
+        with pytest.raises(NotImplementedError):
+            compressor.compress_context(
+                _SAMPLE_CONTEXT,
+                strategy=CompressionStrategy.ABSTRACTIVE_SUMMARY,
+            )
+
+
+class TestDecompressContext:
+    def test_returns_content_with_metadata(self, compressor):
+        compressed = compressor.compress_context(
+            _SAMPLE_CONTEXT,
+            strategy=CompressionStrategy.HIERARCHICAL_SUMMARY,
+        )
+        result = compressor.decompress_context(compressed)
+        assert "_compression_metadata" in result
+        meta = result["_compression_metadata"]
+        assert meta["strategy_used"] == "hierarchical_summary"
+        assert compressed.access_count == 1
+
+
+class TestCompressionStats:
+    def test_returns_config(self, compressor):
+        stats = compressor.get_compression_stats()
+        assert stats["default_strategy"] == "hierarchical_summary"
+        assert stats["default_level"] == "moderate"
+
+
+class TestEdgeCases:
+    def test_empty_context(self, compressor):
+        result = compressor.compress_context(
+            {},
+            strategy=CompressionStrategy.EXTRACTIVE_SUMMARY,
+        )
+        assert result.content == {}
+
+    def test_short_text(self, compressor):
+        result = compressor.compress_context(
+            {"text": "Hi"},
+            strategy=CompressionStrategy.EXTRACTIVE_SUMMARY,
+        )
+        assert "text" in result.content
+
+    def test_custom_config(self):
+        config = CompressionConfig(
+            max_context_size=1000,
+            strategy=CompressionStrategy.KEYWORD_EXTRACTION,
+            level=CompressionLevel.HEAVY,
+            preserve_keywords=["renewable", "energy"],
+            relevance_threshold=0.5,
+        )
+        c = ContextCompressor(config=config)
+        result = c.compress_context(_SAMPLE_CONTEXT)
+        assert result.strategy_used == CompressionStrategy.KEYWORD_EXTRACTION

--- a/tests/unit/test_knowledge_store.py
+++ b/tests/unit/test_knowledge_store.py
@@ -1,0 +1,299 @@
+"""Tests for the KnowledgeStore memory system."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from felix_agent_sdk.memory.knowledge_store import (
+    ConfidenceLevel,
+    KnowledgeEntry,
+    KnowledgeQuery,
+    KnowledgeStore,
+    KnowledgeType,
+)
+
+
+# ------------------------------------------------------------------
+# KnowledgeEntry
+# ------------------------------------------------------------------
+
+
+class TestKnowledgeEntry:
+    def test_construction(self):
+        entry = KnowledgeEntry(
+            knowledge_id="abc123",
+            knowledge_type=KnowledgeType.AGENT_INSIGHT,
+            content={"text": "insight"},
+            confidence_level=ConfidenceLevel.HIGH,
+            source_agent="research-1",
+            domain="testing",
+        )
+        assert entry.knowledge_id == "abc123"
+        assert entry.success_rate == 1.0
+        assert entry.is_deleted is False
+
+    def test_to_dict_from_dict_roundtrip(self):
+        entry = KnowledgeEntry(
+            knowledge_id="rt1",
+            knowledge_type=KnowledgeType.TASK_RESULT,
+            content={"key": "value", "nested": [1, 2]},
+            confidence_level=ConfidenceLevel.VERIFIED,
+            source_agent="agent-x",
+            domain="science",
+            tags=["alpha", "beta"],
+            related_entries=["other-1"],
+        )
+        d = entry.to_dict()
+        restored = KnowledgeEntry.from_dict(d)
+        assert restored.knowledge_id == entry.knowledge_id
+        assert restored.knowledge_type == entry.knowledge_type
+        assert restored.content == entry.content
+        assert restored.tags == entry.tags
+        assert restored.related_entries == entry.related_entries
+
+
+class TestKnowledgeTypes:
+    def test_all_types_exist(self):
+        expected = {
+            "task_result", "agent_insight", "pattern_recognition",
+            "failure_analysis", "optimization_data", "domain_expertise",
+            "tool_instruction", "file_location",
+        }
+        assert {t.value for t in KnowledgeType} == expected
+
+    def test_confidence_ordering(self):
+        levels = list(ConfidenceLevel)
+        assert levels == [
+            ConfidenceLevel.LOW,
+            ConfidenceLevel.MEDIUM,
+            ConfidenceLevel.HIGH,
+            ConfidenceLevel.VERIFIED,
+        ]
+
+
+# ------------------------------------------------------------------
+# KnowledgeStore CRUD
+# ------------------------------------------------------------------
+
+
+class TestKnowledgeStoreCRUD:
+    def test_add_and_retrieve(self, knowledge_store):
+        kid = knowledge_store.add_entry(
+            knowledge_type=KnowledgeType.AGENT_INSIGHT,
+            content={"text": "hello world"},
+            confidence_level=ConfidenceLevel.HIGH,
+            source_agent="agent-1",
+            domain="test",
+        )
+        entry = knowledge_store.get_entry_by_id(kid)
+        assert entry is not None
+        assert entry.content["text"] == "hello world"
+        assert entry.domain == "test"
+
+    def test_deterministic_id(self, knowledge_store):
+        """Same content + agent + domain → same ID (dedup)."""
+        kid1 = knowledge_store.add_entry(
+            knowledge_type=KnowledgeType.TASK_RESULT,
+            content={"a": 1},
+            confidence_level=ConfidenceLevel.LOW,
+            source_agent="agt",
+            domain="d",
+        )
+        kid2 = knowledge_store.add_entry(
+            knowledge_type=KnowledgeType.TASK_RESULT,
+            content={"a": 1},
+            confidence_level=ConfidenceLevel.LOW,
+            source_agent="agt",
+            domain="d",
+        )
+        assert kid1 == kid2
+
+    def test_update_entry(self, knowledge_store):
+        kid = knowledge_store.add_entry(
+            knowledge_type=KnowledgeType.DOMAIN_EXPERTISE,
+            content={"old": True},
+            confidence_level=ConfidenceLevel.MEDIUM,
+            source_agent="a",
+            domain="d",
+        )
+        assert knowledge_store.update_entry(kid, {"content": {"new": True}})
+        entry = knowledge_store.get_entry_by_id(kid)
+        assert entry.content == {"new": True}
+
+    def test_update_confidence(self, knowledge_store):
+        kid = knowledge_store.add_entry(
+            knowledge_type=KnowledgeType.AGENT_INSIGHT,
+            content={"x": 1},
+            confidence_level=ConfidenceLevel.LOW,
+            source_agent="a",
+            domain="d",
+        )
+        knowledge_store.update_entry(kid, {"confidence_level": ConfidenceLevel.VERIFIED})
+        entry = knowledge_store.get_entry_by_id(kid)
+        assert entry.confidence_level == ConfidenceLevel.VERIFIED
+
+    def test_update_nonexistent(self, knowledge_store):
+        assert knowledge_store.update_entry("nope", {"domain": "x"}) is False
+
+    def test_soft_delete(self, knowledge_store):
+        kid = knowledge_store.add_entry(
+            knowledge_type=KnowledgeType.TASK_RESULT,
+            content={"x": 1},
+            confidence_level=ConfidenceLevel.LOW,
+            source_agent="a",
+            domain="d",
+        )
+        assert knowledge_store.delete_entry(kid) is True
+        assert knowledge_store.get_entry_by_id(kid) is None
+
+    def test_delete_nonexistent(self, knowledge_store):
+        assert knowledge_store.delete_entry("nope") is False
+
+    def test_batch_add(self, knowledge_store):
+        entries = [
+            {
+                "knowledge_type": KnowledgeType.AGENT_INSIGHT,
+                "content": {"n": i},
+                "confidence_level": ConfidenceLevel.MEDIUM,
+                "source_agent": f"a-{i}",
+                "domain": "batch",
+            }
+            for i in range(5)
+        ]
+        ids = knowledge_store.batch_add(entries)
+        assert len(ids) == 5
+
+
+# ------------------------------------------------------------------
+# KnowledgeStore queries
+# ------------------------------------------------------------------
+
+
+class TestKnowledgeStoreQueries:
+    @pytest.fixture(autouse=True)
+    def _seed(self, knowledge_store):
+        self.store = knowledge_store
+        self.store.add_entry(
+            KnowledgeType.AGENT_INSIGHT, {"text": "insight one"},
+            ConfidenceLevel.HIGH, "agent-1", "science", tags=["physics"],
+        )
+        self.store.add_entry(
+            KnowledgeType.TASK_RESULT, {"text": "result two"},
+            ConfidenceLevel.LOW, "agent-2", "engineering",
+        )
+        self.store.add_entry(
+            KnowledgeType.AGENT_INSIGHT, {"text": "insight three"},
+            ConfidenceLevel.VERIFIED, "agent-3", "science", tags=["chemistry"],
+        )
+
+    def test_by_type(self):
+        entries = self.store.get_entries_by_type(KnowledgeType.AGENT_INSIGHT)
+        assert len(entries) == 2
+
+    def test_by_domain(self):
+        entries = self.store.get_entries_by_domain("science")
+        assert len(entries) == 2
+
+    def test_min_confidence(self):
+        entries = self.store.search(
+            KnowledgeQuery(min_confidence=ConfidenceLevel.HIGH)
+        )
+        assert all(
+            e.confidence_level in (ConfidenceLevel.HIGH, ConfidenceLevel.VERIFIED)
+            for e in entries
+        )
+
+    def test_content_keywords(self):
+        entries = self.store.search(
+            KnowledgeQuery(content_keywords=["insight"])
+        )
+        assert len(entries) == 2
+
+    def test_text_search(self):
+        entries = self.store.search(
+            KnowledgeQuery(search_text="insight")
+        )
+        assert len(entries) >= 1
+
+    def test_empty_result(self):
+        entries = self.store.search(
+            KnowledgeQuery(domains=["nonexistent"])
+        )
+        assert entries == []
+
+
+# ------------------------------------------------------------------
+# Relationships
+# ------------------------------------------------------------------
+
+
+class TestKnowledgeStoreRelationships:
+    def test_add_and_get_relationship(self, knowledge_store):
+        kid1 = knowledge_store.add_entry(
+            KnowledgeType.AGENT_INSIGHT, {"x": 1},
+            ConfidenceLevel.HIGH, "a", "d",
+        )
+        kid2 = knowledge_store.add_entry(
+            KnowledgeType.AGENT_INSIGHT, {"x": 2},
+            ConfidenceLevel.HIGH, "b", "d",
+        )
+        knowledge_store.add_relationship(kid1, kid2, "supports", confidence=0.9)
+
+        rels = knowledge_store.get_relationships(kid1)
+        assert len(rels) >= 1
+        assert any(r["target_id"] == kid2 for r in rels)
+
+    def test_bidirectional_lookup(self, knowledge_store):
+        kid1 = knowledge_store.add_entry(
+            KnowledgeType.TASK_RESULT, {"a": 1},
+            ConfidenceLevel.LOW, "a", "d",
+        )
+        kid2 = knowledge_store.add_entry(
+            KnowledgeType.TASK_RESULT, {"b": 2},
+            ConfidenceLevel.LOW, "b", "d",
+        )
+        knowledge_store.add_relationship(kid1, kid2)
+        # Query from the target side
+        rels = knowledge_store.get_relationships(kid2)
+        assert len(rels) >= 1
+
+
+# ------------------------------------------------------------------
+# Success rate / cleanup / summary
+# ------------------------------------------------------------------
+
+
+class TestKnowledgeStoreUtilities:
+    def test_update_success_rate(self, knowledge_store):
+        kid = knowledge_store.add_entry(
+            KnowledgeType.OPTIMIZATION_DATA, {"x": 1},
+            ConfidenceLevel.MEDIUM, "a", "d",
+        )
+        knowledge_store.update_success_rate(kid, 0.42)
+        entry = knowledge_store.get_entry_by_id(kid)
+        assert abs(entry.success_rate - 0.42) < 1e-6
+
+    def test_cleanup_old_entries(self, knowledge_store):
+        kid = knowledge_store.add_entry(
+            KnowledgeType.TASK_RESULT, {"old": True},
+            ConfidenceLevel.LOW, "a", "d",
+        )
+        knowledge_store.delete_entry(kid)
+        # With max_age_days=0 it should purge immediately
+        removed = knowledge_store.cleanup_old_entries(max_age_days=0)
+        assert removed >= 1
+
+    def test_summary(self, knowledge_store):
+        knowledge_store.add_entry(
+            KnowledgeType.AGENT_INSIGHT, {"x": 1},
+            ConfidenceLevel.HIGH, "a", "d",
+        )
+        summary = knowledge_store.get_summary()
+        assert summary["total_entries"] >= 1
+        assert "relationships" in summary
+
+    def test_semantic_search_not_implemented(self, knowledge_store):
+        with pytest.raises(NotImplementedError):
+            knowledge_store.semantic_search([0.1, 0.2, 0.3])

--- a/tests/unit/test_task_memory.py
+++ b/tests/unit/test_task_memory.py
@@ -1,0 +1,245 @@
+"""Tests for the TaskMemory pattern recognition system."""
+
+from __future__ import annotations
+
+import pytest
+
+from felix_agent_sdk.memory.task_memory import (
+    TaskComplexity,
+    TaskExecution,
+    TaskMemory,
+    TaskMemoryQuery,
+    TaskOutcome,
+    TaskPattern,
+    _extract_keywords,
+)
+
+
+# ------------------------------------------------------------------
+# Data classes
+# ------------------------------------------------------------------
+
+
+class TestTaskPattern:
+    def test_roundtrip(self):
+        pattern = TaskPattern(
+            pattern_id="p1",
+            task_type="analysis",
+            complexity=TaskComplexity.COMPLEX,
+            keywords=["data", "statistics"],
+            typical_duration=30.0,
+            success_rate=0.85,
+            failure_modes=["timeout"],
+            optimal_strategies=["parallel"],
+            required_agents=["research"],
+            context_requirements={"min_context_size": 1000},
+        )
+        d = pattern.to_dict()
+        restored = TaskPattern.from_dict(d)
+        assert restored.pattern_id == "p1"
+        assert restored.complexity == TaskComplexity.COMPLEX
+        assert restored.keywords == ["data", "statistics"]
+
+
+class TestTaskExecution:
+    def test_roundtrip(self):
+        exe = TaskExecution(
+            execution_id="e1",
+            task_description="analyse data",
+            task_type="analysis",
+            complexity=TaskComplexity.MODERATE,
+            outcome=TaskOutcome.SUCCESS,
+            duration=10.0,
+            agents_used=["research-1"],
+            strategies_used=["parallel"],
+            context_size=500,
+            error_messages=[],
+            success_metrics={"accuracy": 0.95},
+            patterns_matched=["p1"],
+        )
+        d = exe.to_dict()
+        restored = TaskExecution.from_dict(d)
+        assert restored.outcome == TaskOutcome.SUCCESS
+        assert restored.success_metrics == {"accuracy": 0.95}
+
+
+class TestKeywordExtraction:
+    def test_extracts_meaningful_words(self):
+        kw = _extract_keywords("Analyse the complex statistical data patterns")
+        assert "analyse" in kw
+        assert "complex" in kw
+        assert "the" not in kw  # stopword
+
+    def test_filters_short_words(self):
+        kw = _extract_keywords("a an the big cat sat on mat")
+        assert "the" not in kw
+        assert "sat" not in kw  # 3 chars, but > 3 required
+
+    def test_empty_input(self):
+        assert _extract_keywords("") == []
+
+
+# ------------------------------------------------------------------
+# TaskMemory
+# ------------------------------------------------------------------
+
+
+class TestTaskMemoryRecording:
+    def test_record_creates_execution(self, task_memory):
+        eid = task_memory.record_task_execution(
+            task_description="Analyse renewable energy data patterns",
+            task_type="analysis",
+            complexity=TaskComplexity.MODERATE,
+            outcome=TaskOutcome.SUCCESS,
+            duration=15.0,
+            agents_used=["research-1"],
+            strategies_used=["parallel"],
+            context_size=500,
+        )
+        assert isinstance(eid, str)
+        assert len(eid) == 16
+
+    def test_record_creates_pattern(self, task_memory):
+        task_memory.record_task_execution(
+            task_description="Analyse renewable energy data patterns",
+            task_type="analysis",
+            complexity=TaskComplexity.MODERATE,
+            outcome=TaskOutcome.SUCCESS,
+            duration=15.0,
+            agents_used=["research-1"],
+            strategies_used=["parallel"],
+            context_size=500,
+        )
+        patterns = task_memory.get_patterns(
+            TaskMemoryQuery(task_types=["analysis"])
+        )
+        assert len(patterns) >= 1
+
+    def test_second_execution_updates_pattern(self, task_memory):
+        """Two executions with same keywords should update the same pattern."""
+        task_memory.record_task_execution(
+            task_description="Analyse renewable energy data patterns",
+            task_type="analysis",
+            complexity=TaskComplexity.MODERATE,
+            outcome=TaskOutcome.SUCCESS,
+            duration=10.0,
+            agents_used=["research-1"],
+            strategies_used=["parallel"],
+            context_size=500,
+        )
+        task_memory.record_task_execution(
+            task_description="Analyse renewable energy data patterns",
+            task_type="analysis",
+            complexity=TaskComplexity.MODERATE,
+            outcome=TaskOutcome.FAILURE,
+            duration=20.0,
+            agents_used=["research-1"],
+            strategies_used=["sequential"],
+            context_size=600,
+            error_messages=["timeout exceeded"],
+        )
+        patterns = task_memory.get_patterns(
+            TaskMemoryQuery(task_types=["analysis"])
+        )
+        assert len(patterns) >= 1
+        # Pattern should have been updated (usage_count > 1)
+        p = patterns[0]
+        assert p.usage_count >= 2
+
+
+class TestTaskMemoryPatternMatching:
+    def test_keyword_overlap_threshold(self, task_memory):
+        """Pattern matching requires 50% keyword overlap."""
+        task_memory.record_task_execution(
+            task_description="Analyse complex statistical data patterns",
+            task_type="analysis",
+            complexity=TaskComplexity.COMPLEX,
+            outcome=TaskOutcome.SUCCESS,
+            duration=10.0,
+            agents_used=["research"],
+            strategies_used=["parallel"],
+            context_size=500,
+        )
+        # This should NOT match (completely different keywords)
+        task_memory.record_task_execution(
+            task_description="Write marketing blog post content",
+            task_type="writing",
+            complexity=TaskComplexity.SIMPLE,
+            outcome=TaskOutcome.SUCCESS,
+            duration=5.0,
+            agents_used=["writer"],
+            strategies_used=["sequential"],
+            context_size=200,
+        )
+        analysis_patterns = task_memory.get_patterns(
+            TaskMemoryQuery(task_types=["analysis"])
+        )
+        writing_patterns = task_memory.get_patterns(
+            TaskMemoryQuery(task_types=["writing"])
+        )
+        # They should be separate patterns
+        assert len(analysis_patterns) >= 1
+        assert len(writing_patterns) >= 1
+
+
+class TestStrategyRecommendation:
+    def test_recommend_with_history(self, task_memory):
+        task_memory.record_task_execution(
+            task_description="Analyse complex statistical data patterns",
+            task_type="analysis",
+            complexity=TaskComplexity.COMPLEX,
+            outcome=TaskOutcome.SUCCESS,
+            duration=15.0,
+            agents_used=["research", "analysis"],
+            strategies_used=["parallel", "deep_dive"],
+            context_size=1000,
+        )
+        rec = task_memory.recommend_strategy(
+            "Analyse statistical data distributions",
+            "analysis",
+            TaskComplexity.COMPLEX,
+        )
+        assert rec["success_probability"] > 0
+        assert len(rec["strategies"]) > 0
+
+    def test_recommend_without_history(self, task_memory):
+        rec = task_memory.recommend_strategy(
+            "Completely new task type",
+            "unknown",
+            TaskComplexity.SIMPLE,
+        )
+        assert abs(rec["success_probability"]) < 1e-9
+        assert rec["strategies"] == []
+
+
+class TestTaskMemorySummaryAndCleanup:
+    def test_summary(self, task_memory):
+        task_memory.record_task_execution(
+            task_description="test task for summary",
+            task_type="test",
+            complexity=TaskComplexity.SIMPLE,
+            outcome=TaskOutcome.SUCCESS,
+            duration=1.0,
+            agents_used=["a"],
+            strategies_used=["s"],
+            context_size=100,
+        )
+        summary = task_memory.get_memory_summary()
+        assert summary["total_patterns"] >= 1
+        assert summary["total_executions"] >= 1
+
+    def test_cleanup(self, task_memory):
+        task_memory.record_task_execution(
+            task_description="old pattern cleanup test task",
+            task_type="cleanup",
+            complexity=TaskComplexity.SIMPLE,
+            outcome=TaskOutcome.FAILURE,
+            duration=1.0,
+            agents_used=["a"],
+            strategies_used=["s"],
+            context_size=100,
+            error_messages=["fail"],
+        )
+        # With max_age_days=0, should clean up the single-use failure pattern
+        removed = task_memory.cleanup_old_patterns(max_age_days=0, min_usage_count=2)
+        assert removed >= 1


### PR DESCRIPTION
## Summary

- **New: Pluggable backend interface** — `BaseBackend` ABC with `store/get/query/delete/count/search_text`. `SQLiteBackend` as default with FTS5, dynamic schema, operator-based filters (`$gt`, `$lt`, `$in`, `$contains`)
- **Port: KnowledgeStore** — entries with confidence tags, domain organisation, relationship tracking, text search, soft delete, batch ops, cleanup. 3,010 lines → 466 lines
- **Port: TaskMemory** — pattern recognition (50% keyword overlap), strategy recommendation, execution recording. 727 lines → 600 lines
- **Port: ContextCompressor** — extractive, keyword, hierarchical, relevance, progressive strategies. Abstractive stubbed (needs provider). 568 lines → 489 lines
- **621 tests passing**, 0 failures

## Attribution

- Backend interface + SQLite: new code (normal commits)
- KnowledgeStore, TaskMemory, ContextCompressor: algorithms from CalebisGross/felix, refactored for backend interface (`Co-authored-by: Caleb Gross`)

## What's excluded (per plan)

- `semantic_search()` — stubbed with `NotImplementedError` (needs embedding provider)
- `abstractive_summary()` — stubbed (needs LLM provider)
- `workflow_history.py` — deferred to Phase 6
- `audit_log.py` — Felix-internal, not ported

## Test plan

- [x] `pytest tests/ -v` — 621 passed, 12 skipped
- [x] `ruff check src/` — clean
- [x] `python -c "from felix_agent_sdk import KnowledgeStore, TaskMemory, ContextCompressor"` — OK
- [ ] Review backend abstraction boundary
- [ ] Verify KnowledgeStore CRUD round-trips match Felix behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)