### PR TITLE
feat: port workflow runner and add template system (#8)

### DIFF
--- a/src/felix_agent_sdk/__init__.py
+++ b/src/felix_agent_sdk/__init__.py
@@ -33,6 +33,7 @@ from felix_agent_sdk.providers import (
 from felix_agent_sdk.communication import CentralPost, Message, MessageType, Spoke
 from felix_agent_sdk.memory import ContextCompressor, KnowledgeStore, TaskMemory
 from felix_agent_sdk.tokens import TokenBudget
+from felix_agent_sdk.workflows import FelixWorkflow, WorkflowConfig, run_felix_workflow
 
 __all__ = [
     "__version__",
@@ -61,6 +62,10 @@ __all__ = [
     "KnowledgeStore",
     "TaskMemory",
     "ContextCompressor",
+    # Workflows
+    "FelixWorkflow",
+    "run_felix_workflow",
+    "WorkflowConfig",
     # Tokens
     "TokenBudget",
 ]

--- a/src/felix_agent_sdk/workflows/__init__.py
+++ b/src/felix_agent_sdk/workflows/__init__.py
@@ -1,9 +1,25 @@
 """Felix workflow orchestration.
 
 High-level workflow runner and pre-built templates for common patterns.
-Planned exports: run_felix_workflow.
-
-Status: Stub — implementation in feat/workflows branch.
 """
 
-__all__: list[str] = []
+from felix_agent_sdk.workflows.config import (
+    SynthesisStrategy,
+    WorkflowConfig,
+    WorkflowPhase,
+    WorkflowResult,
+)
+from felix_agent_sdk.workflows.context_builder import CollaborativeContextBuilder
+from felix_agent_sdk.workflows.runner import FelixWorkflow, run_felix_workflow
+from felix_agent_sdk.workflows.synthesizer import WorkflowSynthesizer
+
+__all__ = [
+    "FelixWorkflow",
+    "run_felix_workflow",
+    "WorkflowConfig",
+    "WorkflowResult",
+    "WorkflowPhase",
+    "SynthesisStrategy",
+    "CollaborativeContextBuilder",
+    "WorkflowSynthesizer",
+]

--- a/src/felix_agent_sdk/workflows/config.py
+++ b/src/felix_agent_sdk/workflows/config.py
@@ -1,0 +1,82 @@
+"""Workflow configuration and result types for the Felix Agent SDK.
+
+Defines the declarative configuration that parameterises the workflow
+runner and the structured result it produces.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+from felix_agent_sdk.core.helix import HelixConfig
+from felix_agent_sdk.memory.compression import CompressionConfig
+
+
+# ------------------------------------------------------------------
+# Enums
+# ------------------------------------------------------------------
+
+
+class WorkflowPhase(Enum):
+    """High-level workflow phases (mirrors helix position phases)."""
+
+    EXPLORATION = "exploration"
+    ANALYSIS = "analysis"
+    SYNTHESIS = "synthesis"
+
+
+class SynthesisStrategy(Enum):
+    """How the workflow synthesises agent results into a final output."""
+
+    BEST_RESULT = "best_result"
+    COMPRESSED_MERGE = "compressed_merge"
+    ROUND_ROBIN = "round_robin"
+
+
+# ------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------
+
+
+@dataclass
+class WorkflowConfig:
+    """Declarative configuration for a :class:`FelixWorkflow` run.
+
+    Templates produce instances of this class via ``create_config()``
+    factory functions.
+    """
+
+    helix_config: HelixConfig = field(default_factory=HelixConfig.default)
+    team_composition: list[tuple[str, dict[str, Any]]] = field(
+        default_factory=lambda: [
+            ("research", {}),
+            ("analysis", {}),
+            ("critic", {}),
+        ]
+    )
+    confidence_threshold: float = 0.80
+    max_rounds: int = 3
+    synthesis_strategy: SynthesisStrategy = SynthesisStrategy.COMPRESSED_MERGE
+    max_agents: int = 10
+    enable_context_compression: bool = True
+    compression_config: Optional[CompressionConfig] = None
+
+
+# ------------------------------------------------------------------
+# Result
+# ------------------------------------------------------------------
+
+
+@dataclass
+class WorkflowResult:
+    """Structured output from a :class:`FelixWorkflow` run."""
+
+    synthesis: str
+    agent_results: list[Any] = field(default_factory=list)
+    total_rounds: int = 0
+    final_confidence: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)

--- a/src/felix_agent_sdk/workflows/context_builder.py
+++ b/src/felix_agent_sdk/workflows/context_builder.py
@@ -1,0 +1,199 @@
+"""Collaborative context builder for Felix Agent SDK.
+
+Accumulates agent outputs and builds enriched context for subsequent
+agent processing rounds. Supports relevance scoring, deduplication,
+and version tracking.
+
+Algorithms ported from CalebisGross/felix ``src/workflows/context_builder.py``.
+Refactored to remove CentralPost/MemoryFacade coupling.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Contribution:
+    """A single agent's contribution to the collaborative context."""
+
+    agent_id: str
+    agent_type: str
+    content: str
+    confidence: float
+    phase: str
+    timestamp: float = field(default_factory=time.time)
+
+
+class CollaborativeContextBuilder:
+    """Builds enriched context from multiple agent contributions.
+
+    Each processing round, agents add their results via
+    :meth:`add_contribution`. The builder then provides merged context
+    for the next round via :meth:`build_context` and
+    :meth:`get_context_history`.
+    """
+
+    def __init__(self) -> None:
+        self._contributions: list[Contribution] = []
+        self._version: int = 0
+
+    # ------------------------------------------------------------------
+    # Add / query contributions
+    # ------------------------------------------------------------------
+
+    @property
+    def version(self) -> int:
+        """Context version — incremented on each contribution."""
+        return self._version
+
+    @property
+    def contribution_count(self) -> int:
+        return len(self._contributions)
+
+    def add_contribution(
+        self,
+        agent_id: str,
+        agent_type: str,
+        content: str,
+        confidence: float,
+        phase: str = "exploration",
+    ) -> None:
+        """Record an agent's output as a contribution."""
+        self._contributions.append(
+            Contribution(
+                agent_id=agent_id,
+                agent_type=agent_type,
+                content=content,
+                confidence=confidence,
+                phase=phase,
+            )
+        )
+        self._version += 1
+
+    def add_from_result(self, result: Any) -> None:
+        """Add a contribution from an :class:`LLMResult` object."""
+        self.add_contribution(
+            agent_id=result.agent_id,
+            agent_type=result.position_info.get("phase", "exploration"),
+            content=result.content,
+            confidence=result.confidence,
+            phase=result.position_info.get("phase", "exploration"),
+        )
+
+    # ------------------------------------------------------------------
+    # Context building
+    # ------------------------------------------------------------------
+
+    def build_context(self, max_entries: int = 10) -> str:
+        """Build a merged context string, most relevant first.
+
+        Contributions are scored by recency and confidence, then the top
+        *max_entries* are selected and formatted.
+        """
+        scored = self._score_contributions()
+        scored.sort(key=lambda pair: pair[1], reverse=True)
+        selected = scored[:max_entries]
+
+        if not selected:
+            return ""
+
+        parts: list[str] = []
+        for contrib, _score in selected:
+            parts.append(
+                f"[{contrib.agent_id} ({contrib.phase}), "
+                f"confidence={contrib.confidence:.2f}]: "
+                f"{contrib.content}"
+            )
+        return "\n\n".join(parts)
+
+    def get_context_history(self, max_entries: int = 10) -> list[dict[str, Any]]:
+        """Return contributions formatted for ``LLMTask.context_history``.
+
+        Each entry is ``{"agent_id": ..., "content": ...}``.
+        """
+        scored = self._score_contributions()
+        scored.sort(key=lambda pair: pair[1], reverse=True)
+        return [{"agent_id": c.agent_id, "content": c.content} for c, _ in scored[:max_entries]]
+
+    def merge_contributions(self) -> dict[str, Any]:
+        """Merge all contributions into a dict suitable for
+        :meth:`ContextCompressor.compress_context`.
+        """
+        merged: dict[str, Any] = {}
+        for contrib in self._contributions:
+            key = f"{contrib.agent_id}_{contrib.phase}"
+            merged[key] = contrib.content
+        return merged
+
+    # ------------------------------------------------------------------
+    # Deduplication
+    # ------------------------------------------------------------------
+
+    def deduplicate(self, similarity_threshold: float = 0.6) -> int:
+        """Remove near-duplicate contributions.
+
+        Uses Jaccard similarity on keyword sets. Returns the number of
+        contributions removed.
+        """
+        if len(self._contributions) < 2:
+            return 0
+
+        to_keep: list[Contribution] = [self._contributions[0]]
+        removed = 0
+
+        for contrib in self._contributions[1:]:
+            is_dup = False
+            kw_new = self._extract_keywords(contrib.content)
+            for existing in to_keep:
+                kw_existing = self._extract_keywords(existing.content)
+                sim = self._jaccard(kw_new, kw_existing)
+                if sim >= similarity_threshold:
+                    is_dup = True
+                    break
+            if is_dup:
+                removed += 1
+            else:
+                to_keep.append(contrib)
+
+        self._contributions = to_keep
+        return removed
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _score_contributions(self) -> list[tuple[Contribution, float]]:
+        """Score contributions by recency + confidence."""
+        if not self._contributions:
+            return []
+
+        now = time.time()
+        scored: list[tuple[Contribution, float]] = []
+        for i, contrib in enumerate(self._contributions):
+            # Recency: more recent = higher (0.0 – 0.5)
+            age = now - contrib.timestamp
+            recency = max(0.0, 0.5 - age * 0.01)
+            # Confidence weight (0.0 – 0.5)
+            conf = contrib.confidence * 0.5
+            scored.append((contrib, recency + conf))
+        return scored
+
+    @staticmethod
+    def _extract_keywords(text: str) -> set[str]:
+        words = re.findall(r"\b\w{4,}\b", text.lower())
+        return set(words)
+
+    @staticmethod
+    def _jaccard(a: set[str], b: set[str]) -> float:
+        if not a and not b:
+            return 1.0
+        if not a or not b:
+            return 0.0
+        return len(a & b) / len(a | b)

--- a/src/felix_agent_sdk/workflows/runner.py
+++ b/src/felix_agent_sdk/workflows/runner.py
@@ -1,0 +1,258 @@
+"""Felix workflow orchestration runner.
+
+Wires agents, communication hub, and memory into a complete multi-agent
+workflow. This is the top-level integration point of the SDK.
+
+Core orchestration loop ported from CalebisGross/felix
+``src/workflows/felix_workflow.py``. Refactored to use discrete rounds,
+the SDK's provider abstraction, and the pluggable backend stack.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from felix_agent_sdk.agents.base import AgentState
+from felix_agent_sdk.agents.factory import AgentFactory
+from felix_agent_sdk.agents.llm_agent import LLMAgent, LLMResult, LLMTask
+from felix_agent_sdk.communication.central_post import CentralPost
+from felix_agent_sdk.communication.messages import Message, MessageType
+from felix_agent_sdk.communication.spoke import SpokeManager
+from felix_agent_sdk.providers.base import BaseProvider
+from felix_agent_sdk.workflows.config import WorkflowConfig, WorkflowResult
+from felix_agent_sdk.workflows.context_builder import CollaborativeContextBuilder
+from felix_agent_sdk.workflows.synthesizer import WorkflowSynthesizer
+
+logger = logging.getLogger(__name__)
+
+
+class FelixWorkflow:
+    """Multi-agent workflow runner using helical agent progression.
+
+    Orchestrates agent team creation, discrete processing rounds with
+    helix-driven temperature/prompting, message routing through the
+    CentralPost hub, and final synthesis.
+
+    Args:
+        config: Workflow configuration (team composition, thresholds, …).
+        provider: LLM provider shared by all agents.
+    """
+
+    def __init__(self, config: WorkflowConfig, provider: BaseProvider) -> None:
+        self._config = config
+        self._provider = provider
+        self._factory = AgentFactory(provider, helix_config=config.helix_config)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(self, task_description: str, context: str = "") -> WorkflowResult:
+        """Execute the workflow end-to-end.
+
+        1. Setup — hub, spokes, agents.
+        2. Processing rounds — advance time, process tasks, route messages.
+        3. Synthesis — combine results.
+        4. Cleanup — shutdown hub and spokes.
+
+        Args:
+            task_description: The task for agents to work on.
+            context: Optional initial context / background.
+
+        Returns:
+            :class:`WorkflowResult` with synthesised output and metadata.
+        """
+        start = time.monotonic()
+
+        # --- Setup ---
+        hub = CentralPost(max_agents=self._config.max_agents)
+        spoke_mgr = SpokeManager(hub=hub)
+        agents = self._create_team(spoke_mgr)
+        builder = CollaborativeContextBuilder()
+        all_results: list[LLMResult] = []
+
+        try:
+            # --- Processing rounds ---
+            rounds_completed = 0
+            converged = False
+            time_step = 1.0 / max(self._config.max_rounds, 1)
+
+            for round_num in range(self._config.max_rounds):
+                current_time = (round_num + 1) * time_step
+                round_results = self._run_round(
+                    agents=agents,
+                    spoke_mgr=spoke_mgr,
+                    builder=builder,
+                    task_description=task_description,
+                    context=context,
+                    current_time=current_time,
+                )
+                all_results.extend(round_results)
+                rounds_completed = round_num + 1
+
+                # Dynamic spawning hook (no-op for now)
+                self._check_dynamic_spawning(agents, round_results)
+
+                # Convergence check
+                if round_results:
+                    avg_confidence = sum(r.confidence for r in round_results) / len(round_results)
+                    if avg_confidence >= self._config.confidence_threshold:
+                        logger.info(
+                            "Workflow converged at round %d (confidence=%.3f)",
+                            rounds_completed,
+                            avg_confidence,
+                        )
+                        converged = True
+                        break
+
+            # --- Synthesis ---
+            synthesizer = WorkflowSynthesizer(self._provider, self._config)
+            synthesis = synthesizer.synthesize(all_results, task_description)
+
+            # --- Result ---
+            final_confidence = 0.0
+            if all_results:
+                final_confidence = sum(r.confidence for r in all_results) / len(all_results)
+
+            elapsed = time.monotonic() - start
+            total_tokens = sum(r.token_budget_used for r in all_results)
+
+            return WorkflowResult(
+                synthesis=synthesis,
+                agent_results=all_results,
+                total_rounds=rounds_completed,
+                final_confidence=final_confidence,
+                metadata={
+                    "elapsed_seconds": round(elapsed, 3),
+                    "total_tokens": total_tokens,
+                    "converged": converged,
+                    "agents_count": len(agents),
+                    "team_composition": [(a.agent_type, a.agent_id) for a in agents],
+                },
+            )
+        finally:
+            spoke_mgr.shutdown_all()
+            hub.shutdown()
+
+    # ------------------------------------------------------------------
+    # Internal — team setup
+    # ------------------------------------------------------------------
+
+    def _create_team(self, spoke_mgr: SpokeManager) -> list[LLMAgent]:
+        """Spawn agents from config and connect them to the hub."""
+        composition = self._config.team_composition
+        n = len(composition)
+        agents: list[LLMAgent] = []
+
+        for i, (agent_type, kwargs) in enumerate(composition):
+            spawn_time = i / max(n, 1)
+            agent = self._factory.create_agent(
+                agent_type=agent_type,
+                spawn_time=spawn_time,
+                **kwargs,
+            )
+            spoke_mgr.create_spoke(agent.agent_id, agent=agent)
+            agents.append(agent)
+
+        return agents
+
+    # ------------------------------------------------------------------
+    # Internal — processing round
+    # ------------------------------------------------------------------
+
+    def _run_round(
+        self,
+        agents: list[LLMAgent],
+        spoke_mgr: SpokeManager,
+        builder: CollaborativeContextBuilder,
+        task_description: str,
+        context: str,
+        current_time: float,
+    ) -> list[LLMResult]:
+        """Execute one processing round across all agents."""
+        round_results: list[LLMResult] = []
+
+        for agent in agents:
+            # Spawn if eligible and still waiting
+            if agent.state == AgentState.WAITING and agent.can_spawn(current_time):
+                agent.spawn(current_time)
+
+            if agent.state != AgentState.ACTIVE:
+                continue
+
+            # Advance position
+            agent.update_position(current_time)
+
+            # Check helical checkpoint gating
+            if not agent.should_process_at_checkpoint():
+                continue
+
+            # Build task with collaborative context
+            task = LLMTask(
+                task_id=f"{agent.agent_id}-r{current_time:.2f}",
+                description=task_description,
+                context=context,
+                context_history=builder.get_context_history(),
+            )
+
+            result = agent.process_task(task)
+            agent.mark_checkpoint_processed()
+
+            # Feed result back to collaborative context
+            builder.add_from_result(result)
+
+            # Send status message through hub
+            spoke = spoke_mgr.get_spoke(agent.agent_id)
+            if spoke:
+                spoke.send(
+                    Message(
+                        sender_id=agent.agent_id,
+                        message_type=MessageType.STATUS_UPDATE,
+                        content={
+                            "confidence": result.confidence,
+                            "phase": result.position_info.get("phase", ""),
+                            "progress": result.position_info.get("progress", 0.0),
+                        },
+                    )
+                )
+
+            round_results.append(result)
+
+        # Route messages through the hub
+        spoke_mgr.process_all_messages()
+
+        return round_results
+
+    # ------------------------------------------------------------------
+    # Dynamic spawning hook
+    # ------------------------------------------------------------------
+
+    def _check_dynamic_spawning(
+        self,
+        agents: list[LLMAgent],
+        round_results: list[LLMResult],
+    ) -> None:
+        """Hook for confidence-driven dynamic spawning.
+
+        Currently a no-op. Will be wired when the ``spawning/`` module
+        is implemented.
+        """
+
+    # ------------------------------------------------------------------
+    # Convenience function
+    # ------------------------------------------------------------------
+
+
+def run_felix_workflow(
+    config: WorkflowConfig,
+    provider: BaseProvider,
+    task_description: str,
+    context: str = "",
+) -> WorkflowResult:
+    """Run a Felix workflow in one call.
+
+    Thin wrapper around :class:`FelixWorkflow` for simple use cases.
+    """
+    workflow = FelixWorkflow(config, provider)
+    return workflow.run(task_description, context=context)

--- a/src/felix_agent_sdk/workflows/runner.py
+++ b/src/felix_agent_sdk/workflows/runner.py
@@ -17,7 +17,7 @@ from felix_agent_sdk.agents.base import AgentState
 from felix_agent_sdk.agents.factory import AgentFactory
 from felix_agent_sdk.agents.llm_agent import LLMAgent, LLMResult, LLMTask
 from felix_agent_sdk.communication.central_post import CentralPost
-from felix_agent_sdk.communication.messages import Message, MessageType
+from felix_agent_sdk.communication.messages import MessageType
 from felix_agent_sdk.communication.spoke import SpokeManager
 from felix_agent_sdk.providers.base import BaseProvider
 from felix_agent_sdk.workflows.config import WorkflowConfig, WorkflowResult
@@ -205,16 +205,13 @@ class FelixWorkflow:
             # Send status message through hub
             spoke = spoke_mgr.get_spoke(agent.agent_id)
             if spoke:
-                spoke.send(
-                    Message(
-                        sender_id=agent.agent_id,
-                        message_type=MessageType.STATUS_UPDATE,
-                        content={
-                            "confidence": result.confidence,
-                            "phase": result.position_info.get("phase", ""),
-                            "progress": result.position_info.get("progress", 0.0),
-                        },
-                    )
+                spoke.send_message(
+                    message_type=MessageType.STATUS_UPDATE,
+                    content={
+                        "confidence": result.confidence,
+                        "phase": result.position_info.get("phase", ""),
+                        "progress": result.position_info.get("progress", 0.0),
+                    },
                 )
 
             round_results.append(result)

--- a/src/felix_agent_sdk/workflows/synthesizer.py
+++ b/src/felix_agent_sdk/workflows/synthesizer.py
@@ -1,0 +1,132 @@
+"""Workflow synthesis for the Felix Agent SDK.
+
+Lightweight replacement for Felix's full SynthesisEngine. Combines agent
+results into a single final output via one of three strategies.
+
+Synthesis patterns derived from CalebisGross/felix workflow orchestration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from felix_agent_sdk.agents.factory import AgentFactory
+from felix_agent_sdk.agents.llm_agent import LLMResult, LLMTask
+from felix_agent_sdk.memory.compression import (
+    CompressionConfig,
+    CompressionStrategy,
+    ContextCompressor,
+)
+from felix_agent_sdk.providers.base import BaseProvider
+from felix_agent_sdk.workflows.config import SynthesisStrategy, WorkflowConfig
+
+logger = logging.getLogger(__name__)
+
+
+class WorkflowSynthesizer:
+    """Synthesises agent results into a final workflow output.
+
+    Args:
+        provider: LLM provider for the synthesis call.
+        config: Workflow configuration (determines strategy and compression).
+    """
+
+    def __init__(self, provider: BaseProvider, config: WorkflowConfig) -> None:
+        self._provider = provider
+        self._config = config
+
+    def synthesize(
+        self,
+        results: list[LLMResult],
+        task_description: str,
+    ) -> str:
+        """Produce a final synthesis string from *results*.
+
+        Strategy dispatch:
+
+        * ``BEST_RESULT`` — return the highest-confidence result.
+        * ``COMPRESSED_MERGE`` — compress all results then run a
+          synthesiser agent at ``t = 1.0``.
+        * ``ROUND_ROBIN`` — return the last round's best result.
+        """
+        if not results:
+            return ""
+
+        strategy = self._config.synthesis_strategy
+
+        if strategy == SynthesisStrategy.BEST_RESULT:
+            return self._best_result(results)
+        if strategy == SynthesisStrategy.ROUND_ROBIN:
+            return self._round_robin(results)
+        # Default: COMPRESSED_MERGE
+        return self._compressed_merge(results, task_description)
+
+    # ------------------------------------------------------------------
+    # Strategies
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _best_result(results: list[LLMResult]) -> str:
+        """Pick the single highest-confidence result."""
+        best = max(results, key=lambda r: r.confidence)
+        return best.content
+
+    @staticmethod
+    def _round_robin(results: list[LLMResult]) -> str:
+        """Return the last result (most recent round's output)."""
+        return results[-1].content
+
+    def _compressed_merge(
+        self,
+        results: list[LLMResult],
+        task_description: str,
+    ) -> str:
+        """Compress all results, then run a synthesis agent."""
+        # Build context from all agent outputs
+        context_dict: dict[str, Any] = {
+            "task": task_description,
+        }
+        for r in results:
+            key = f"{r.agent_id}_{r.position_info.get('phase', 'unknown')}"
+            context_dict[key] = r.content
+
+        # Optionally compress
+        if self._config.enable_context_compression:
+            compressor = ContextCompressor(
+                config=self._config.compression_config
+                or CompressionConfig(
+                    strategy=CompressionStrategy.HIERARCHICAL_SUMMARY,
+                )
+            )
+            compressed = compressor.compress_context(context_dict)
+            context_text = json.dumps(compressed.content, indent=2)
+        else:
+            context_text = "\n\n".join(f"[{r.agent_id}]: {r.content}" for r in results)
+
+        # Create a synthesis agent at the bottom of the helix (t=1.0)
+        factory = AgentFactory(
+            self._provider,
+            helix_config=self._config.helix_config,
+        )
+        synth_agent = factory.create_agent(
+            agent_type="llm",
+            agent_id="synthesizer",
+            spawn_time=0.0,
+        )
+        # Move to synthesis phase
+        synth_agent.spawn(current_time=0.0)
+        synth_agent._progress = 1.0  # noqa: SLF001 — place at synthesis end
+
+        task = LLMTask(
+            task_id="synthesis",
+            description=(
+                f"Synthesise the following agent outputs into a coherent, "
+                f"concise final answer for the task: {task_description}"
+            ),
+            context=context_text,
+        )
+
+        result = synth_agent.process_task(task)
+        return result.content

--- a/src/felix_agent_sdk/workflows/templates/__init__.py
+++ b/src/felix_agent_sdk/workflows/templates/__init__.py
@@ -1,8 +1,17 @@
-"""Pre-built workflow templates.
+"""Pre-built workflow templates for common patterns."""
 
-Planned exports: research, analysis, review templates.
+from felix_agent_sdk.workflows.templates.analysis import (
+    create_config as analysis_config,
+)
+from felix_agent_sdk.workflows.templates.research import (
+    create_config as research_config,
+)
+from felix_agent_sdk.workflows.templates.review import (
+    create_config as review_config,
+)
 
-Status: Stub — implementation in feat/workflows branch.
-"""
-
-__all__: list[str] = []
+__all__ = [
+    "research_config",
+    "analysis_config",
+    "review_config",
+]

--- a/src/felix_agent_sdk/workflows/templates/analysis.py
+++ b/src/felix_agent_sdk/workflows/templates/analysis.py
@@ -1,0 +1,34 @@
+"""Analysis workflow template — data-focused convergence.
+
+Uses a narrow helix (``fast_convergence``) with emphasis on analysis
+agents for precision-oriented tasks.
+"""
+
+from __future__ import annotations
+
+from felix_agent_sdk.core.helix import HelixConfig
+from felix_agent_sdk.workflows.config import SynthesisStrategy, WorkflowConfig
+
+
+def create_config(
+    confidence_threshold: float = 0.85,
+    max_rounds: int = 3,
+) -> WorkflowConfig:
+    """Create an analysis-focused workflow configuration.
+
+    Team: 1 Research + 2 Analysis + 1 Critic.
+    Higher confidence threshold for data-focused precision.
+    """
+    return WorkflowConfig(
+        helix_config=HelixConfig.fast_convergence(),
+        team_composition=[
+            ("research", {}),
+            ("analysis", {}),
+            ("analysis", {}),
+            ("critic", {}),
+        ],
+        confidence_threshold=confidence_threshold,
+        max_rounds=max_rounds,
+        synthesis_strategy=SynthesisStrategy.COMPRESSED_MERGE,
+        max_agents=10,
+    )

--- a/src/felix_agent_sdk/workflows/templates/research.py
+++ b/src/felix_agent_sdk/workflows/templates/research.py
@@ -1,0 +1,34 @@
+"""Research workflow template — broad exploration to synthesis.
+
+Uses a wide helix (``research_heavy``) with multiple research agents
+for deep exploration before analysis and critique.
+"""
+
+from __future__ import annotations
+
+from felix_agent_sdk.core.helix import HelixConfig
+from felix_agent_sdk.workflows.config import SynthesisStrategy, WorkflowConfig
+
+
+def create_config(
+    confidence_threshold: float = 0.75,
+    max_rounds: int = 4,
+) -> WorkflowConfig:
+    """Create a research-focused workflow configuration.
+
+    Team: 2 Research + 1 Analysis + 1 Critic.
+    Lower confidence threshold and more rounds allow deeper exploration.
+    """
+    return WorkflowConfig(
+        helix_config=HelixConfig.research_heavy(),
+        team_composition=[
+            ("research", {}),
+            ("research", {}),
+            ("analysis", {}),
+            ("critic", {}),
+        ],
+        confidence_threshold=confidence_threshold,
+        max_rounds=max_rounds,
+        synthesis_strategy=SynthesisStrategy.COMPRESSED_MERGE,
+        max_agents=10,
+    )

--- a/src/felix_agent_sdk/workflows/templates/review.py
+++ b/src/felix_agent_sdk/workflows/templates/review.py
@@ -1,0 +1,34 @@
+"""Review workflow template — multi-perspective critique.
+
+Uses a balanced helix (``default``) with emphasis on critic agents
+for thorough multi-perspective review and refinement.
+"""
+
+from __future__ import annotations
+
+from felix_agent_sdk.core.helix import HelixConfig
+from felix_agent_sdk.workflows.config import SynthesisStrategy, WorkflowConfig
+
+
+def create_config(
+    confidence_threshold: float = 0.80,
+    max_rounds: int = 3,
+) -> WorkflowConfig:
+    """Create a review-focused workflow configuration.
+
+    Team: 1 Research + 1 Analysis + 2 Critic.
+    Multi-perspective critique with balanced helix.
+    """
+    return WorkflowConfig(
+        helix_config=HelixConfig.default(),
+        team_composition=[
+            ("research", {}),
+            ("analysis", {}),
+            ("critic", {}),
+            ("critic", {}),
+        ],
+        confidence_threshold=confidence_threshold,
+        max_rounds=max_rounds,
+        synthesis_strategy=SynthesisStrategy.COMPRESSED_MERGE,
+        max_agents=10,
+    )

--- a/tests/integration/test_workflow_pipeline.py
+++ b/tests/integration/test_workflow_pipeline.py
@@ -1,0 +1,231 @@
+"""Integration tests for the full Felix workflow pipeline.
+
+These tests run the complete workflow with a mocked LLM provider,
+verifying that agents, communication hub, context builder, and
+synthesizer all integrate correctly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from felix_agent_sdk.providers.base import BaseProvider
+from felix_agent_sdk.providers.types import CompletionResult
+from felix_agent_sdk.workflows.config import SynthesisStrategy, WorkflowConfig
+from felix_agent_sdk.workflows.runner import FelixWorkflow, run_felix_workflow
+from felix_agent_sdk.workflows.templates import (
+    analysis_config,
+    research_config,
+    review_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_CALL_COUNTER = 0
+
+
+def _make_multi_response_provider() -> BaseProvider:
+    """Mock provider that returns distinct responses per call."""
+    global _CALL_COUNTER  # noqa: PLW0603
+    _CALL_COUNTER = 0
+
+    provider = MagicMock(spec=BaseProvider)
+
+    responses = [
+        "The analysis reveals several key findings about renewable energy adoption. "
+        "Solar capacity has grown 40% year-over-year with significant grid integration improvements.",
+        "Further investigation shows distributed generation improves resilience. "
+        "Battery storage costs have declined by 85% since 2010 enabling broader adoption.",
+        "Critical review: the data supports the correlation between renewable adoption and stability. "
+        "However, intermittency remains a concern requiring detailed attention to storage solutions.",
+        "Comprehensive synthesis integrating all findings into a coherent framework. "
+        "The evidence strongly supports accelerating renewable energy deployment.",
+    ]
+
+    def _complete(messages, **kwargs):
+        global _CALL_COUNTER  # noqa: PLW0603
+        idx = _CALL_COUNTER % len(responses)
+        _CALL_COUNTER += 1
+        return CompletionResult(
+            content=responses[idx],
+            model="test-model",
+            usage={"prompt_tokens": 100, "completion_tokens": 60, "total_tokens": 160},
+        )
+
+    provider.complete.side_effect = _complete
+    provider.count_tokens.return_value = 100
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline tests
+# ---------------------------------------------------------------------------
+
+
+class TestResearchWorkflow:
+    def test_full_pipeline(self):
+        provider = _make_multi_response_provider()
+        config = research_config()
+        workflow = FelixWorkflow(config, provider)
+
+        result = workflow.run("Analyse the impact of renewable energy on grid stability")
+
+        assert result.synthesis != ""
+        assert result.total_rounds >= 1
+        assert result.final_confidence > 0
+        assert len(result.agent_results) > 0
+        assert result.metadata["agents_count"] == 4
+        assert provider.complete.called
+
+    def test_agents_produce_results(self):
+        provider = _make_multi_response_provider()
+        config = research_config(max_rounds=2)
+        workflow = FelixWorkflow(config, provider)
+
+        result = workflow.run("Research task")
+
+        # Each agent that processed should have a result
+        for agent_result in result.agent_results:
+            assert agent_result.content != ""
+            assert agent_result.confidence > 0
+            assert agent_result.agent_id != ""
+
+
+class TestAnalysisWorkflow:
+    def test_convergence(self):
+        """High-confidence responses should cause early convergence."""
+        provider = MagicMock(spec=BaseProvider)
+        provider.complete.return_value = CompletionResult(
+            content=(
+                "Detailed analysis with evidence-based conclusions. The data indicates "
+                "strong correlation supported by multiple research studies demonstrating "
+                "clear patterns. Furthermore, the specific metrics show 95% confidence "
+                "in the primary hypothesis."
+            ),
+            model="test-model",
+            usage={"prompt_tokens": 50, "completion_tokens": 50, "total_tokens": 100},
+        )
+        provider.count_tokens.return_value = 50
+
+        # Use analysis config but with lower threshold to make convergence easier
+        config = analysis_config(confidence_threshold=0.50)
+        workflow = FelixWorkflow(config, provider)
+
+        result = workflow.run("Analyse data patterns")
+
+        assert result.metadata.get("converged") is True
+        assert result.total_rounds <= config.max_rounds
+
+
+class TestReviewWorkflow:
+    def test_multi_critic(self):
+        provider = _make_multi_response_provider()
+        config = review_config()
+        workflow = FelixWorkflow(config, provider)
+
+        result = workflow.run("Review the proposal")
+
+        # Review template has 2 critics
+        agent_types = [t for t, _ in result.metadata["team_composition"]]
+        assert agent_types.count("critic") == 2
+        assert result.synthesis != ""
+
+
+class TestForcedSynthesis:
+    def test_runs_all_rounds_when_threshold_unreachable(self):
+        provider = _make_multi_response_provider()
+        config = WorkflowConfig(
+            confidence_threshold=0.99,  # Unreachable
+            max_rounds=2,
+            team_composition=[("research", {}), ("analysis", {})],
+        )
+        workflow = FelixWorkflow(config, provider)
+
+        result = workflow.run("Test task")
+
+        assert result.total_rounds == 2
+        assert result.metadata.get("converged") is False
+
+
+class TestWorkflowCleanup:
+    def test_hub_shutdown(self):
+        """Verify hub and spokes are cleaned up even on normal completion."""
+        provider = _make_multi_response_provider()
+        config = WorkflowConfig(
+            max_rounds=1,
+            team_composition=[("research", {})],
+        )
+        workflow = FelixWorkflow(config, provider)
+
+        result = workflow.run("Test cleanup")
+
+        # If cleanup failed we'd get errors on subsequent runs
+        result2 = workflow.run("Second run")
+        assert result2.synthesis != ""
+
+
+class TestSynthesisStrategies:
+    def test_best_result_strategy(self):
+        provider = _make_multi_response_provider()
+        config = WorkflowConfig(
+            synthesis_strategy=SynthesisStrategy.BEST_RESULT,
+            max_rounds=1,
+            team_composition=[("research", {}), ("analysis", {})],
+        )
+        workflow = FelixWorkflow(config, provider)
+
+        result = workflow.run("Test best result")
+
+        assert result.synthesis != ""
+        # Should not make an extra provider call for synthesis
+        # (calls = agent processing only)
+
+    def test_round_robin_strategy(self):
+        provider = _make_multi_response_provider()
+        config = WorkflowConfig(
+            synthesis_strategy=SynthesisStrategy.ROUND_ROBIN,
+            max_rounds=1,
+            team_composition=[("research", {})],
+        )
+        workflow = FelixWorkflow(config, provider)
+
+        result = workflow.run("Test round robin")
+        assert result.synthesis != ""
+
+
+class TestWorkflowMetadata:
+    def test_metadata_fields(self):
+        provider = _make_multi_response_provider()
+        config = WorkflowConfig(
+            max_rounds=1,
+            team_composition=[("research", {}), ("critic", {})],
+        )
+        workflow = FelixWorkflow(config, provider)
+
+        result = workflow.run("Metadata test")
+
+        assert "elapsed_seconds" in result.metadata
+        assert "total_tokens" in result.metadata
+        assert "converged" in result.metadata
+        assert "agents_count" in result.metadata
+        assert result.metadata["agents_count"] == 2
+        assert result.metadata["total_tokens"] >= 0
+
+
+class TestConvenienceFunction:
+    def test_run_felix_workflow(self):
+        provider = _make_multi_response_provider()
+        config = WorkflowConfig(
+            max_rounds=1,
+            team_composition=[("research", {})],
+        )
+
+        result = run_felix_workflow(config, provider, "Convenience test")
+
+        assert result.synthesis != ""
+        assert isinstance(result.total_rounds, int)

--- a/tests/integration/test_workflow_pipeline.py
+++ b/tests/integration/test_workflow_pipeline.py
@@ -26,13 +26,9 @@ from felix_agent_sdk.workflows.templates import (
 # Fixtures
 # ---------------------------------------------------------------------------
 
-_CALL_COUNTER = 0
-
-
 def _make_multi_response_provider() -> BaseProvider:
     """Mock provider that returns distinct responses per call."""
-    global _CALL_COUNTER  # noqa: PLW0603
-    _CALL_COUNTER = 0
+    call_count = [0]
 
     provider = MagicMock(spec=BaseProvider)
 
@@ -48,9 +44,8 @@ def _make_multi_response_provider() -> BaseProvider:
     ]
 
     def _complete(messages, **kwargs):
-        global _CALL_COUNTER  # noqa: PLW0603
-        idx = _CALL_COUNTER % len(responses)
-        _CALL_COUNTER += 1
+        idx = call_count[0] % len(responses)
+        call_count[0] += 1
         return CompletionResult(
             content=responses[idx],
             model="test-model",

--- a/tests/unit/test_context_builder.py
+++ b/tests/unit/test_context_builder.py
@@ -1,0 +1,122 @@
+"""Tests for CollaborativeContextBuilder."""
+
+from __future__ import annotations
+
+import pytest
+
+from felix_agent_sdk.workflows.context_builder import (
+    CollaborativeContextBuilder,
+    Contribution,
+)
+
+
+class TestContribution:
+    def test_construction(self):
+        c = Contribution(
+            agent_id="agent-1",
+            agent_type="research",
+            content="Some findings",
+            confidence=0.75,
+            phase="exploration",
+        )
+        assert c.agent_id == "agent-1"
+        assert c.timestamp > 0
+
+
+class TestContextBuilderBasics:
+    def test_empty(self):
+        builder = CollaborativeContextBuilder()
+        assert builder.contribution_count == 0
+        assert builder.version == 0
+        assert builder.build_context() == ""
+        assert builder.get_context_history() == []
+
+    def test_add_contribution(self):
+        builder = CollaborativeContextBuilder()
+        builder.add_contribution("a1", "research", "findings", 0.7, "exploration")
+        assert builder.contribution_count == 1
+        assert builder.version == 1
+
+    def test_version_increments(self):
+        builder = CollaborativeContextBuilder()
+        builder.add_contribution("a1", "research", "x", 0.5, "exploration")
+        builder.add_contribution("a2", "analysis", "y", 0.6, "analysis")
+        assert builder.version == 2
+
+
+class TestBuildContext:
+    def test_builds_formatted_string(self):
+        builder = CollaborativeContextBuilder()
+        builder.add_contribution("a1", "research", "Finding A", 0.8, "exploration")
+        builder.add_contribution("a2", "analysis", "Finding B", 0.6, "analysis")
+
+        ctx = builder.build_context()
+        assert "a1" in ctx
+        assert "Finding A" in ctx
+        assert "a2" in ctx
+
+    def test_max_entries(self):
+        builder = CollaborativeContextBuilder()
+        for i in range(20):
+            builder.add_contribution(f"a{i}", "research", f"content {i}", 0.5, "exploration")
+
+        ctx = builder.build_context(max_entries=3)
+        # Should not contain all 20 agents
+        assert ctx.count("[a") <= 3
+
+    def test_higher_confidence_ranked_higher(self):
+        builder = CollaborativeContextBuilder()
+        builder.add_contribution("low", "research", "low conf", 0.1, "exploration")
+        builder.add_contribution("high", "research", "high conf", 0.9, "exploration")
+
+        history = builder.get_context_history(max_entries=1)
+        assert len(history) == 1
+        assert history[0]["agent_id"] == "high"
+
+
+class TestContextHistory:
+    def test_format(self):
+        builder = CollaborativeContextBuilder()
+        builder.add_contribution("a1", "research", "content here", 0.7, "exploration")
+
+        history = builder.get_context_history()
+        assert len(history) == 1
+        assert history[0]["agent_id"] == "a1"
+        assert history[0]["content"] == "content here"
+
+
+class TestMergeContributions:
+    def test_merge_keys(self):
+        builder = CollaborativeContextBuilder()
+        builder.add_contribution("a1", "research", "Alpha", 0.7, "exploration")
+        builder.add_contribution("a2", "analysis", "Beta", 0.8, "analysis")
+
+        merged = builder.merge_contributions()
+        assert "a1_exploration" in merged
+        assert "a2_analysis" in merged
+        assert merged["a1_exploration"] == "Alpha"
+
+
+class TestDeduplication:
+    def test_removes_duplicates(self):
+        builder = CollaborativeContextBuilder()
+        builder.add_contribution("a1", "research", "The renewable energy data shows patterns", 0.7, "exploration")
+        builder.add_contribution("a2", "research", "The renewable energy data shows clear patterns", 0.6, "exploration")
+        builder.add_contribution("a3", "analysis", "Financial markets are volatile today", 0.8, "analysis")
+
+        removed = builder.deduplicate(similarity_threshold=0.5)
+        assert removed >= 1
+        assert builder.contribution_count < 3
+
+    def test_no_duplicates(self):
+        builder = CollaborativeContextBuilder()
+        builder.add_contribution("a1", "research", "Topic alpha about science", 0.7, "exploration")
+        builder.add_contribution("a2", "analysis", "Topic beta about finance", 0.8, "analysis")
+
+        removed = builder.deduplicate()
+        assert removed == 0
+        assert builder.contribution_count == 2
+
+    def test_empty_dedup(self):
+        builder = CollaborativeContextBuilder()
+        assert builder.deduplicate() == 0

--- a/tests/unit/test_synthesizer.py
+++ b/tests/unit/test_synthesizer.py
@@ -1,0 +1,120 @@
+"""Tests for WorkflowSynthesizer."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from felix_agent_sdk.agents.llm_agent import LLMResult
+from felix_agent_sdk.providers.base import BaseProvider
+from felix_agent_sdk.providers.types import CompletionResult
+from felix_agent_sdk.workflows.config import SynthesisStrategy, WorkflowConfig
+from felix_agent_sdk.workflows.synthesizer import WorkflowSynthesizer
+
+
+def _make_result(agent_id: str, content: str, confidence: float) -> LLMResult:
+    """Create a mock LLMResult for testing."""
+    return LLMResult(
+        agent_id=agent_id,
+        task_id="test",
+        content=content,
+        position_info={"phase": "exploration", "progress": 0.5},
+        completion_result=CompletionResult(
+            content=content,
+            model="test",
+            usage={"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
+        ),
+        processing_time=0.1,
+        confidence=confidence,
+        temperature_used=0.5,
+        token_budget_used=20,
+    )
+
+
+def _make_mock_provider() -> BaseProvider:
+    provider = MagicMock(spec=BaseProvider)
+    provider.complete.return_value = CompletionResult(
+        content="Synthesised final output combining all findings.",
+        model="test-model",
+        usage={"prompt_tokens": 50, "completion_tokens": 30, "total_tokens": 80},
+    )
+    provider.count_tokens.return_value = 50
+    return provider
+
+
+class TestBestResultStrategy:
+    def test_picks_highest_confidence(self):
+        provider = _make_mock_provider()
+        config = WorkflowConfig(synthesis_strategy=SynthesisStrategy.BEST_RESULT)
+        synth = WorkflowSynthesizer(provider, config)
+
+        results = [
+            _make_result("a1", "Low confidence output", 0.3),
+            _make_result("a2", "High confidence output", 0.9),
+            _make_result("a3", "Medium confidence output", 0.6),
+        ]
+
+        output = synth.synthesize(results, "test task")
+        assert output == "High confidence output"
+
+    def test_does_not_call_provider(self):
+        provider = _make_mock_provider()
+        config = WorkflowConfig(synthesis_strategy=SynthesisStrategy.BEST_RESULT)
+        synth = WorkflowSynthesizer(provider, config)
+
+        results = [_make_result("a1", "content", 0.5)]
+        synth.synthesize(results, "task")
+        provider.complete.assert_not_called()
+
+
+class TestRoundRobinStrategy:
+    def test_returns_last_result(self):
+        provider = _make_mock_provider()
+        config = WorkflowConfig(synthesis_strategy=SynthesisStrategy.ROUND_ROBIN)
+        synth = WorkflowSynthesizer(provider, config)
+
+        results = [
+            _make_result("a1", "First", 0.5),
+            _make_result("a2", "Second", 0.6),
+            _make_result("a3", "Third", 0.7),
+        ]
+
+        output = synth.synthesize(results, "task")
+        assert output == "Third"
+
+
+class TestCompressedMergeStrategy:
+    def test_calls_provider(self):
+        provider = _make_mock_provider()
+        config = WorkflowConfig(synthesis_strategy=SynthesisStrategy.COMPRESSED_MERGE)
+        synth = WorkflowSynthesizer(provider, config)
+
+        results = [
+            _make_result("a1", "Finding one", 0.6),
+            _make_result("a2", "Finding two", 0.7),
+        ]
+
+        output = synth.synthesize(results, "Analyse the data")
+        assert provider.complete.called
+        assert len(output) > 0
+
+    def test_without_compression(self):
+        provider = _make_mock_provider()
+        config = WorkflowConfig(
+            synthesis_strategy=SynthesisStrategy.COMPRESSED_MERGE,
+            enable_context_compression=False,
+        )
+        synth = WorkflowSynthesizer(provider, config)
+
+        results = [_make_result("a1", "Data", 0.5)]
+        output = synth.synthesize(results, "task")
+        assert provider.complete.called
+
+
+class TestEmptyResults:
+    def test_empty_returns_empty(self):
+        provider = _make_mock_provider()
+        config = WorkflowConfig()
+        synth = WorkflowSynthesizer(provider, config)
+        assert synth.synthesize([], "task") == ""

--- a/tests/unit/test_workflow_config.py
+++ b/tests/unit/test_workflow_config.py
@@ -1,0 +1,106 @@
+"""Tests for workflow configuration and template configs."""
+
+from __future__ import annotations
+
+import pytest
+
+from felix_agent_sdk.core.helix import HelixConfig
+from felix_agent_sdk.workflows.config import (
+    SynthesisStrategy,
+    WorkflowConfig,
+    WorkflowPhase,
+    WorkflowResult,
+)
+from felix_agent_sdk.workflows.templates import (
+    analysis_config,
+    research_config,
+    review_config,
+)
+
+
+class TestWorkflowPhase:
+    def test_values(self):
+        assert WorkflowPhase.EXPLORATION.value == "exploration"
+        assert WorkflowPhase.ANALYSIS.value == "analysis"
+        assert WorkflowPhase.SYNTHESIS.value == "synthesis"
+        assert len(WorkflowPhase) == 3
+
+
+class TestSynthesisStrategy:
+    def test_values(self):
+        assert SynthesisStrategy.BEST_RESULT.value == "best_result"
+        assert SynthesisStrategy.COMPRESSED_MERGE.value == "compressed_merge"
+        assert SynthesisStrategy.ROUND_ROBIN.value == "round_robin"
+        assert len(SynthesisStrategy) == 3
+
+
+class TestWorkflowConfig:
+    def test_defaults(self):
+        config = WorkflowConfig()
+        assert config.confidence_threshold == 0.80
+        assert config.max_rounds == 3
+        assert config.synthesis_strategy == SynthesisStrategy.COMPRESSED_MERGE
+        assert config.max_agents == 10
+        assert config.enable_context_compression is True
+        assert len(config.team_composition) == 3
+
+    def test_custom_config(self):
+        config = WorkflowConfig(
+            helix_config=HelixConfig.research_heavy(),
+            team_composition=[("research", {}), ("research", {})],
+            confidence_threshold=0.90,
+            max_rounds=5,
+        )
+        assert config.confidence_threshold == 0.90
+        assert config.max_rounds == 5
+        assert len(config.team_composition) == 2
+
+    def test_default_team_composition(self):
+        config = WorkflowConfig()
+        types = [t for t, _ in config.team_composition]
+        assert "research" in types
+        assert "analysis" in types
+        assert "critic" in types
+
+
+class TestWorkflowResult:
+    def test_construction(self):
+        result = WorkflowResult(
+            synthesis="Final answer",
+            total_rounds=2,
+            final_confidence=0.85,
+        )
+        assert result.synthesis == "Final answer"
+        assert result.total_rounds == 2
+        assert result.agent_results == []
+        assert result.metadata == {}
+        assert result.created_at > 0
+
+
+class TestTemplateConfigs:
+    def test_research_config(self):
+        config = research_config()
+        assert isinstance(config, WorkflowConfig)
+        types = [t for t, _ in config.team_composition]
+        assert types.count("research") == 2
+        assert config.confidence_threshold == 0.75
+        assert config.max_rounds == 4
+
+    def test_analysis_config(self):
+        config = analysis_config()
+        assert isinstance(config, WorkflowConfig)
+        types = [t for t, _ in config.team_composition]
+        assert types.count("analysis") == 2
+        assert config.confidence_threshold == 0.85
+
+    def test_review_config(self):
+        config = review_config()
+        assert isinstance(config, WorkflowConfig)
+        types = [t for t, _ in config.team_composition]
+        assert types.count("critic") == 2
+        assert config.confidence_threshold == 0.80
+
+    def test_custom_thresholds(self):
+        config = research_config(confidence_threshold=0.60, max_rounds=6)
+        assert config.confidence_threshold == 0.60
+        assert config.max_rounds == 6


### PR DESCRIPTION
## Summary

- **WorkflowConfig** — declarative dataclass with helix_config, team_composition, confidence_threshold, max_rounds, synthesis_strategy
- **CollaborativeContextBuilder** — accumulates agent outputs with relevance scoring, deduplication, version tracking. Ported from Felix context_builder.py
- **WorkflowSynthesizer** — 3 strategies: BEST_RESULT (pick highest confidence), COMPRESSED_MERGE (compress + synthesis agent at t=1.0), ROUND_ROBIN (last result)
- **FelixWorkflow** — full orchestration: team spawn via AgentFactory, discrete-round processing with helix-driven checkpoints, CentralPost message routing, convergence detection, synthesis delegation. `run_felix_workflow()` convenience wrapper
- **3 templates** — research (wide helix, 2 research agents), analysis (narrow helix, 2 analysis agents), review (balanced, 2 critics)
- **659 tests passing** (38 new: 28 unit + 10 integration)

## Architecture

```
FelixWorkflow.run(task)
  → AgentFactory.create_agent() per team_composition entry
  → SpokeManager connects agents to CentralPost hub
  → Processing rounds (discrete time steps):
      → Agent.update_position() / should_process_at_checkpoint()
      → LLMAgent.process_task() → LLMResult
      → CollaborativeContextBuilder.add_from_result()
      → Spoke.send_message() through hub
      → Convergence check (avg confidence vs threshold)
  → WorkflowSynthesizer.synthesize()
  → WorkflowResult
```

## Attribution

- Config + templates: new SDK code (normal commits)
- ContextBuilder, Synthesizer, Runner: `Co-authored-by: Caleb Gross` (algorithms from Felix, refactored for SDK)

## Test plan

- [x] `pytest tests/ -v` — 659 passed, 12 skipped
- [x] `ruff check src/` — clean
- [x] `python -c "from felix_agent_sdk import FelixWorkflow, run_felix_workflow, WorkflowConfig"` — OK
- [x] Integration: full pipeline with mocked providers (research, analysis, review templates)
- [x] Convergence: high-confidence responses → early exit before max_rounds
- [x] Forced synthesis: unreachable threshold → runs all rounds then synthesises

🤖 Generated with [Claude Code](https://claude.com/claude-code)