### PR TITLE
feat(events): add event system for SDK observability

### DIFF
--- a/src/felix_agent_sdk/__init__.py
+++ b/src/felix_agent_sdk/__init__.py
@@ -31,6 +31,7 @@ from felix_agent_sdk.providers import (
     auto_detect_provider,
 )
 from felix_agent_sdk.communication import CentralPost, Message, MessageType, Spoke
+from felix_agent_sdk.events import EventBus, EventType, FelixEvent
 from felix_agent_sdk.memory import ContextCompressor, KnowledgeStore, TaskMemory
 from felix_agent_sdk.tokens import TokenBudget
 from felix_agent_sdk.workflows import FelixWorkflow, WorkflowConfig, run_felix_workflow
@@ -66,6 +67,10 @@ __all__ = [
     "FelixWorkflow",
     "run_felix_workflow",
     "WorkflowConfig",
+    # Events
+    "EventBus",
+    "EventType",
+    "FelixEvent",
     # Tokens
     "TokenBudget",
 ]

--- a/src/felix_agent_sdk/agents/llm_agent.py
+++ b/src/felix_agent_sdk/agents/llm_agent.py
@@ -107,8 +107,7 @@ class LLMAgent(Agent, EventEmitterMixin):
 
         self.provider = provider
         self.agent_type = agent_type
-        if event_bus is not None:
-            self.set_event_bus(event_bus)
+        self.set_event_bus(event_bus)
 
         self.temperature_range = temperature_range or _DEFAULT_TEMPERATURE_RANGES.get(
             agent_type, _DEFAULT_TEMP_RANGE

--- a/src/felix_agent_sdk/agents/llm_agent.py
+++ b/src/felix_agent_sdk/agents/llm_agent.py
@@ -19,6 +19,9 @@ from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
 from felix_agent_sdk.agents.base import Agent
 from felix_agent_sdk.core.helix import HelixGeometry
+from felix_agent_sdk.events.bus import EventBus
+from felix_agent_sdk.events.mixins import EventEmitterMixin
+from felix_agent_sdk.events.types import EventType
 from felix_agent_sdk.providers.base import BaseProvider
 from felix_agent_sdk.providers.types import ChatMessage, CompletionResult, MessageRole
 from felix_agent_sdk.tokens.budget import TokenBudget
@@ -76,7 +79,7 @@ _DEFAULT_TEMP_RANGE: Tuple[float, float] = (0.1, 0.9)
 # ---------------------------------------------------------------------------
 
 
-class LLMAgent(Agent):
+class LLMAgent(Agent, EventEmitterMixin):
     """LLM-powered agent that processes tasks via a provider-agnostic interface.
 
     Extends :class:`Agent` with LLM capabilities: adaptive temperature,
@@ -98,11 +101,14 @@ class LLMAgent(Agent):
         temperature_range: Optional[Tuple[float, float]] = None,
         max_tokens: Optional[int] = None,
         token_budget: Optional[TokenBudget] = None,
+        event_bus: Optional[EventBus] = None,
     ) -> None:
         super().__init__(agent_id, helix, spawn_time=spawn_time, velocity=velocity)
 
         self.provider = provider
         self.agent_type = agent_type
+        if event_bus is not None:
+            self.set_event_bus(event_bus)
 
         self.temperature_range = temperature_range or _DEFAULT_TEMPERATURE_RANGES.get(
             agent_type, _DEFAULT_TEMP_RANGE
@@ -308,11 +314,17 @@ class LLMAgent(Agent):
     # ------------------------------------------------------------------
 
     def process_task(self, task: LLMTask) -> LLMResult:
-        """Process a task: prompt ➜ provider call ➜ confidence ➜ result.
+        """Process a task: prompt -> provider call -> confidence -> result.
 
         This is the primary entry point for running an agent on a task.
         """
         start = time.monotonic()
+
+        self.emit_event(
+            EventType.TASK_STARTED,
+            {"task_id": task.task_id, "agent_type": self.agent_type},
+            source=f"agent:{self.agent_id}",
+        )
 
         temperature = self.get_adaptive_temperature()
         system_prompt, user_prompt = self.create_position_aware_prompt(task)
@@ -339,6 +351,21 @@ class LLMAgent(Agent):
             token_budget_used=completion.total_tokens,
         )
         self.processing_results.append(result)
+
+        self.emit_event(
+            EventType.TASK_COMPLETED,
+            {
+                "task_id": task.task_id,
+                "agent_type": self.agent_type,
+                "confidence": round(confidence, 4),
+                "temperature": round(temperature, 4),
+                "tokens": completion.total_tokens,
+                "processing_time": round(elapsed, 4),
+                "phase": result.position_info.get("phase", ""),
+            },
+            source=f"agent:{self.agent_id}",
+        )
+
         return result
 
     # ------------------------------------------------------------------

--- a/src/felix_agent_sdk/communication/central_post.py
+++ b/src/felix_agent_sdk/communication/central_post.py
@@ -16,6 +16,8 @@ from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from felix_agent_sdk.communication.messages import Message, MessageType
 from felix_agent_sdk.communication.registry import AgentRegistry
+from felix_agent_sdk.events.bus import EventBus
+from felix_agent_sdk.events.types import EventType, FelixEvent
 
 if TYPE_CHECKING:
     from felix_agent_sdk.agents.base import Agent
@@ -35,6 +37,14 @@ class AgentLifecycleEvent(Enum):
     SPAWNED = "spawned"
     COMPLETED = "completed"
     FAILED = "failed"
+
+
+# Map legacy lifecycle events to the new EventType system.
+_LIFECYCLE_TO_EVENT_TYPE: Dict[AgentLifecycleEvent, str] = {
+    AgentLifecycleEvent.SPAWNED: EventType.AGENT_SPAWNED,
+    AgentLifecycleEvent.COMPLETED: EventType.AGENT_COMPLETED,
+    AgentLifecycleEvent.FAILED: EventType.AGENT_FAILED,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -65,10 +75,12 @@ class CentralPost:
         max_agents: int = 25,
         enable_metrics: bool = False,
         provider: Optional[BaseProvider] = None,
+        event_bus: Optional[EventBus] = None,
     ) -> None:
         self._max_agents = max_agents
         self._enable_metrics = enable_metrics
         self._provider = provider
+        self._event_bus = event_bus
 
         # Agent tracking
         self._registered_agents: Dict[str, Any] = {}
@@ -545,6 +557,8 @@ class CentralPost:
     def emit_lifecycle_event(self, event: AgentLifecycleEvent, agent_id: str) -> None:
         """Invoke all callbacks registered for *event*.
 
+        Also emits onto the attached :class:`EventBus` if present.
+
         Args:
             event: The lifecycle event that occurred.
             agent_id: The agent ID to pass to each callback.
@@ -557,6 +571,18 @@ class CentralPost:
                     "Lifecycle callback error for event %s, agent %s",
                     event.value,
                     agent_id,
+                )
+
+        # Bridge to EventBus
+        if self._event_bus is not None:
+            event_type = _LIFECYCLE_TO_EVENT_TYPE.get(event)
+            if event_type is not None:
+                self._event_bus.emit(
+                    FelixEvent(
+                        event_type=event_type,
+                        source=f"agent:{agent_id}",
+                        data={"agent_id": agent_id},
+                    )
                 )
 
     # ------------------------------------------------------------------

--- a/src/felix_agent_sdk/events/__init__.py
+++ b/src/felix_agent_sdk/events/__init__.py
@@ -1,0 +1,17 @@
+"""Felix event system for SDK observability.
+
+Provides a synchronous pub/sub event bus, typed events, and a mixin
+for emitting events from any component.
+"""
+
+from felix_agent_sdk.events.bus import EventBus, EventCallback
+from felix_agent_sdk.events.mixins import EventEmitterMixin
+from felix_agent_sdk.events.types import EventType, FelixEvent
+
+__all__ = [
+    "EventBus",
+    "EventCallback",
+    "EventEmitterMixin",
+    "EventType",
+    "FelixEvent",
+]

--- a/src/felix_agent_sdk/events/bus.py
+++ b/src/felix_agent_sdk/events/bus.py
@@ -1,0 +1,166 @@
+"""Synchronous publish/subscribe event bus.
+
+The ``EventBus`` is the central nervous system of Felix observability.
+Components emit events; observers subscribe by exact type or prefix pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import defaultdict
+from typing import Callable, Dict, List
+
+from felix_agent_sdk.events.types import FelixEvent
+
+logger = logging.getLogger(__name__)
+
+# Type alias for event callbacks
+EventCallback = Callable[[FelixEvent], None]
+
+
+class EventBus:
+    """Synchronous event bus with prefix-pattern subscriptions.
+
+    Thread-safe. Callbacks are invoked inline during :meth:`emit`.
+    If a callback raises, the exception is logged and the remaining
+    callbacks still execute (same isolation pattern as
+    ``CentralPost.emit_lifecycle_event``).
+
+    Examples::
+
+        bus = EventBus()
+
+        # Exact match
+        bus.subscribe("workflow.started", my_handler)
+
+        # Prefix match — catches all agent.* events
+        bus.subscribe("agent.*", my_agent_handler)
+
+        # Catch-all
+        bus.subscribe_all(my_logger)
+    """
+
+    def __init__(self) -> None:
+        self._exact: Dict[str, List[EventCallback]] = defaultdict(list)
+        self._prefix: Dict[str, List[EventCallback]] = defaultdict(list)
+        self._catch_all: List[EventCallback] = []
+        self._lock = threading.Lock()
+        self._history: List[FelixEvent] = []
+        self._record_history = False
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    def enable_history(self, enabled: bool = True) -> None:
+        """Toggle event recording. When enabled, all emitted events are
+        stored in :attr:`history` for later inspection."""
+        with self._lock:
+            self._record_history = enabled
+            if not enabled:
+                self._history.clear()
+
+    @property
+    def history(self) -> List[FelixEvent]:
+        """Read-only copy of recorded events (empty if history is disabled)."""
+        with self._lock:
+            return list(self._history)
+
+    # ------------------------------------------------------------------
+    # Subscribe / unsubscribe
+    # ------------------------------------------------------------------
+
+    def subscribe(self, event_type: str, callback: EventCallback) -> None:
+        """Register *callback* for events matching *event_type*.
+
+        If *event_type* ends with ``".*"``, the callback receives every
+        event whose type starts with the prefix (e.g. ``"agent.*"``
+        matches ``"agent.spawned"``, ``"agent.completed"``, etc.).
+        """
+        with self._lock:
+            if event_type.endswith(".*"):
+                prefix = event_type[:-1]  # "agent.*" → "agent."
+                self._prefix[prefix].append(callback)
+            else:
+                self._exact[event_type].append(callback)
+
+    def subscribe_all(self, callback: EventCallback) -> None:
+        """Register *callback* for **every** event."""
+        with self._lock:
+            self._catch_all.append(callback)
+
+    def unsubscribe(self, event_type: str, callback: EventCallback) -> None:
+        """Remove *callback* from *event_type* subscriptions."""
+        with self._lock:
+            if event_type.endswith(".*"):
+                prefix = event_type[:-1]
+                cbs = self._prefix.get(prefix, [])
+            else:
+                cbs = self._exact.get(event_type, [])
+            if callback in cbs:
+                cbs.remove(callback)
+
+    def unsubscribe_all(self, callback: EventCallback) -> None:
+        """Remove *callback* from the catch-all list."""
+        with self._lock:
+            if callback in self._catch_all:
+                self._catch_all.remove(callback)
+
+    # ------------------------------------------------------------------
+    # Emit
+    # ------------------------------------------------------------------
+
+    def emit(self, event: FelixEvent) -> None:
+        """Dispatch *event* to all matching subscribers.
+
+        Matching order: exact → prefix → catch-all.
+        Exceptions in callbacks are logged and swallowed.
+        """
+        with self._lock:
+            if self._record_history:
+                self._history.append(event)
+
+            targets: List[EventCallback] = []
+
+            # Exact match
+            targets.extend(self._exact.get(event.event_type, []))
+
+            # Prefix match
+            for prefix, cbs in self._prefix.items():
+                if event.event_type.startswith(prefix):
+                    targets.extend(cbs)
+
+            # Catch-all
+            targets.extend(self._catch_all)
+
+        # Invoke outside the lock to avoid deadlocks in callbacks
+        for cb in targets:
+            try:
+                cb(event)
+            except Exception:
+                logger.exception(
+                    "EventBus callback error for %s from %s",
+                    event.event_type,
+                    event.source,
+                )
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    def clear(self) -> None:
+        """Remove all subscriptions and recorded history."""
+        with self._lock:
+            self._exact.clear()
+            self._prefix.clear()
+            self._catch_all.clear()
+            self._history.clear()
+
+    @property
+    def subscriber_count(self) -> int:
+        """Total number of registered callbacks (exact + prefix + catch-all)."""
+        with self._lock:
+            exact_count = sum(len(cbs) for cbs in self._exact.values())
+            prefix_count = sum(len(cbs) for cbs in self._prefix.values())
+            return exact_count + prefix_count + len(self._catch_all)

--- a/src/felix_agent_sdk/events/mixins.py
+++ b/src/felix_agent_sdk/events/mixins.py
@@ -1,0 +1,51 @@
+"""Mixin for classes that emit events onto an EventBus."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from felix_agent_sdk.events.bus import EventBus
+from felix_agent_sdk.events.types import FelixEvent
+
+
+class EventEmitterMixin:
+    """Opt-in mixin that gives any class event-emission capability.
+
+    When an :class:`EventBus` is attached via :meth:`set_event_bus`, calls
+    to :meth:`emit_event` dispatch a :class:`FelixEvent` onto the bus.
+    When no bus is attached, :meth:`emit_event` is a silent no-op —
+    zero overhead for users who don't enable observability.
+    """
+
+    _event_bus: Optional[EventBus] = None
+
+    def set_event_bus(self, bus: Optional[EventBus]) -> None:
+        """Attach or detach an event bus."""
+        self._event_bus = bus
+
+    def emit_event(
+        self,
+        event_type: str,
+        data: Optional[Dict[str, Any]] = None,
+        *,
+        source: Optional[str] = None,
+    ) -> None:
+        """Emit a :class:`FelixEvent` if a bus is attached.
+
+        Args:
+            event_type: Event category (e.g. ``EventType.TASK_STARTED``).
+            data: Arbitrary payload dict.
+            source: Override the default source identifier.
+        """
+        if self._event_bus is None:
+            return
+        event = FelixEvent(
+            event_type=event_type,
+            source=source or self._default_event_source(),
+            data=data or {},
+        )
+        self._event_bus.emit(event)
+
+    def _default_event_source(self) -> str:
+        """Return a default source string. Override for richer identification."""
+        return type(self).__name__

--- a/src/felix_agent_sdk/events/mixins.py
+++ b/src/felix_agent_sdk/events/mixins.py
@@ -15,13 +15,16 @@ class EventEmitterMixin:
     to :meth:`emit_event` dispatch a :class:`FelixEvent` onto the bus.
     When no bus is attached, :meth:`emit_event` is a silent no-op —
     zero overhead for users who don't enable observability.
+
+    Note: ``_event_bus`` is declared as a class-level annotation for type
+    checkers but always written to the *instance* dict via ``set_event_bus``.
     """
 
-    _event_bus: Optional[EventBus] = None
+    _event_bus: Optional[EventBus]
 
     def set_event_bus(self, bus: Optional[EventBus]) -> None:
-        """Attach or detach an event bus."""
-        self._event_bus = bus
+        """Attach or detach an event bus (writes to instance, not class)."""
+        self.__dict__["_event_bus"] = bus
 
     def emit_event(
         self,
@@ -37,7 +40,7 @@ class EventEmitterMixin:
             data: Arbitrary payload dict.
             source: Override the default source identifier.
         """
-        if self._event_bus is None:
+        if getattr(self, "_event_bus", None) is None:
             return
         event = FelixEvent(
             event_type=event_type,

--- a/src/felix_agent_sdk/events/types.py
+++ b/src/felix_agent_sdk/events/types.py
@@ -19,18 +19,19 @@ class EventType(str, Enum):
     so subscribers can match by prefix (e.g. ``"agent.*"``).
     """
 
-    # Agent lifecycle
+    # Agent lifecycle — SPAWNED/COMPLETED/FAILED bridged from CentralPost
     AGENT_SPAWNED = "agent.spawned"
     AGENT_COMPLETED = "agent.completed"
     AGENT_FAILED = "agent.failed"
+    # TODO: emit from Agent.update_position() and should_process_at_checkpoint()
     AGENT_POSITION_UPDATED = "agent.position_updated"
     AGENT_CHECKPOINT = "agent.checkpoint"
 
-    # Task processing
+    # Task processing — emitted from LLMAgent.process_task()
     TASK_STARTED = "task.started"
     TASK_COMPLETED = "task.completed"
 
-    # Workflow lifecycle
+    # Workflow lifecycle — emitted from FelixWorkflow.run()
     WORKFLOW_STARTED = "workflow.started"
     WORKFLOW_ROUND_STARTED = "workflow.round.started"
     WORKFLOW_ROUND_COMPLETED = "workflow.round.completed"
@@ -39,14 +40,15 @@ class EventType(str, Enum):
     WORKFLOW_COMPLETED = "workflow.completed"
 
     # Communication
+    # TODO: emit from CentralPost.queue_message() and _handle_message()
     MESSAGE_QUEUED = "message.queued"
     MESSAGE_PROCESSED = "message.processed"
 
-    # Streaming (wired in PR #3)
+    # Streaming — wired in feat/streaming PR
     STREAM_TOKEN = "stream.token"
     STREAM_COMPLETED = "stream.completed"
 
-    # Dynamic spawning (wired in PR #4)
+    # Dynamic spawning — wired in feat/dynamic-spawning PR
     SPAWN_TRIGGERED = "spawn.triggered"
     SPAWN_COMPLETED = "spawn.completed"
 

--- a/src/felix_agent_sdk/events/types.py
+++ b/src/felix_agent_sdk/events/types.py
@@ -1,0 +1,68 @@
+"""Event type definitions for the Felix observability system.
+
+Provides a unified event model that all SDK components can emit into.
+Events are frozen dataclasses — immutable records of things that happened.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict
+
+
+class EventType(str, Enum):
+    """All observable events in the Felix SDK.
+
+    Naming convention: ``component.action`` with dotted hierarchy
+    so subscribers can match by prefix (e.g. ``"agent.*"``).
+    """
+
+    # Agent lifecycle
+    AGENT_SPAWNED = "agent.spawned"
+    AGENT_COMPLETED = "agent.completed"
+    AGENT_FAILED = "agent.failed"
+    AGENT_POSITION_UPDATED = "agent.position_updated"
+    AGENT_CHECKPOINT = "agent.checkpoint"
+
+    # Task processing
+    TASK_STARTED = "task.started"
+    TASK_COMPLETED = "task.completed"
+
+    # Workflow lifecycle
+    WORKFLOW_STARTED = "workflow.started"
+    WORKFLOW_ROUND_STARTED = "workflow.round.started"
+    WORKFLOW_ROUND_COMPLETED = "workflow.round.completed"
+    WORKFLOW_CONVERGED = "workflow.converged"
+    WORKFLOW_SYNTHESIS_STARTED = "workflow.synthesis.started"
+    WORKFLOW_COMPLETED = "workflow.completed"
+
+    # Communication
+    MESSAGE_QUEUED = "message.queued"
+    MESSAGE_PROCESSED = "message.processed"
+
+    # Streaming (wired in PR #3)
+    STREAM_TOKEN = "stream.token"
+    STREAM_COMPLETED = "stream.completed"
+
+    # Dynamic spawning (wired in PR #4)
+    SPAWN_TRIGGERED = "spawn.triggered"
+    SPAWN_COMPLETED = "spawn.completed"
+
+
+@dataclass(frozen=True)
+class FelixEvent:
+    """An immutable record of something that happened in the SDK.
+
+    Attributes:
+        event_type: The event category (from :class:`EventType` or a custom string).
+        source: Identifies the emitter, e.g. ``"workflow"`` or ``"agent:research-001"``.
+        data: Arbitrary payload. Contents vary by event type.
+        timestamp: Monotonic timestamp (seconds) when the event was created.
+    """
+
+    event_type: str
+    source: str
+    data: Dict[str, Any] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time.monotonic)

--- a/src/felix_agent_sdk/workflows/runner.py
+++ b/src/felix_agent_sdk/workflows/runner.py
@@ -13,12 +13,17 @@ from __future__ import annotations
 import logging
 import time
 
+from typing import Optional
+
 from felix_agent_sdk.agents.base import AgentState
 from felix_agent_sdk.agents.factory import AgentFactory
 from felix_agent_sdk.agents.llm_agent import LLMAgent, LLMResult, LLMTask
 from felix_agent_sdk.communication.central_post import CentralPost
 from felix_agent_sdk.communication.messages import MessageType
 from felix_agent_sdk.communication.spoke import SpokeManager
+from felix_agent_sdk.events.bus import EventBus
+from felix_agent_sdk.events.mixins import EventEmitterMixin
+from felix_agent_sdk.events.types import EventType
 from felix_agent_sdk.providers.base import BaseProvider
 from felix_agent_sdk.workflows.config import WorkflowConfig, WorkflowResult
 from felix_agent_sdk.workflows.context_builder import CollaborativeContextBuilder
@@ -27,7 +32,7 @@ from felix_agent_sdk.workflows.synthesizer import WorkflowSynthesizer
 logger = logging.getLogger(__name__)
 
 
-class FelixWorkflow:
+class FelixWorkflow(EventEmitterMixin):
     """Multi-agent workflow runner using helical agent progression.
 
     Orchestrates agent team creation, discrete processing rounds with
@@ -37,12 +42,20 @@ class FelixWorkflow:
     Args:
         config: Workflow configuration (team composition, thresholds, …).
         provider: LLM provider shared by all agents.
+        event_bus: Optional event bus for observability.
     """
 
-    def __init__(self, config: WorkflowConfig, provider: BaseProvider) -> None:
+    def __init__(
+        self,
+        config: WorkflowConfig,
+        provider: BaseProvider,
+        event_bus: Optional[EventBus] = None,
+    ) -> None:
         self._config = config
         self._provider = provider
         self._factory = AgentFactory(provider, helix_config=config.helix_config)
+        if event_bus is not None:
+            self.set_event_bus(event_bus)
 
     # ------------------------------------------------------------------
     # Public API
@@ -66,11 +79,21 @@ class FelixWorkflow:
         start = time.monotonic()
 
         # --- Setup ---
-        hub = CentralPost(max_agents=self._config.max_agents)
+        hub = CentralPost(max_agents=self._config.max_agents, event_bus=self._event_bus)
         spoke_mgr = SpokeManager(hub=hub)
         agents = self._create_team(spoke_mgr)
         builder = CollaborativeContextBuilder()
         all_results: list[LLMResult] = []
+
+        self.emit_event(
+            EventType.WORKFLOW_STARTED,
+            {
+                "task": task_description,
+                "max_rounds": self._config.max_rounds,
+                "agents_count": len(agents),
+                "team_composition": [(a.agent_type, a.agent_id) for a in agents],
+            },
+        )
 
         try:
             # --- Processing rounds ---
@@ -80,6 +103,13 @@ class FelixWorkflow:
 
             for round_num in range(self._config.max_rounds):
                 current_time = (round_num + 1) * time_step
+                rounds_completed = round_num + 1
+
+                self.emit_event(
+                    EventType.WORKFLOW_ROUND_STARTED,
+                    {"round": rounds_completed, "current_time": round(current_time, 4)},
+                )
+
                 round_results = self._run_round(
                     agents=agents,
                     spoke_mgr=spoke_mgr,
@@ -89,24 +119,39 @@ class FelixWorkflow:
                     current_time=current_time,
                 )
                 all_results.extend(round_results)
-                rounds_completed = round_num + 1
+
+                avg_confidence = 0.0
+                if round_results:
+                    avg_confidence = sum(r.confidence for r in round_results) / len(round_results)
+
+                self.emit_event(
+                    EventType.WORKFLOW_ROUND_COMPLETED,
+                    {
+                        "round": rounds_completed,
+                        "results_count": len(round_results),
+                        "avg_confidence": round(avg_confidence, 4),
+                    },
+                )
 
                 # Dynamic spawning hook (no-op for now)
                 self._check_dynamic_spawning(agents, round_results)
 
                 # Convergence check
-                if round_results:
-                    avg_confidence = sum(r.confidence for r in round_results) / len(round_results)
-                    if avg_confidence >= self._config.confidence_threshold:
-                        logger.info(
-                            "Workflow converged at round %d (confidence=%.3f)",
-                            rounds_completed,
-                            avg_confidence,
-                        )
-                        converged = True
-                        break
+                if round_results and avg_confidence >= self._config.confidence_threshold:
+                    logger.info(
+                        "Workflow converged at round %d (confidence=%.3f)",
+                        rounds_completed,
+                        avg_confidence,
+                    )
+                    self.emit_event(
+                        EventType.WORKFLOW_CONVERGED,
+                        {"round": rounds_completed, "confidence": round(avg_confidence, 4)},
+                    )
+                    converged = True
+                    break
 
             # --- Synthesis ---
+            self.emit_event(EventType.WORKFLOW_SYNTHESIS_STARTED, {})
             synthesizer = WorkflowSynthesizer(self._provider, self._config)
             synthesis = synthesizer.synthesize(all_results, task_description)
 
@@ -118,7 +163,7 @@ class FelixWorkflow:
             elapsed = time.monotonic() - start
             total_tokens = sum(r.token_budget_used for r in all_results)
 
-            return WorkflowResult(
+            result = WorkflowResult(
                 synthesis=synthesis,
                 agent_results=all_results,
                 total_rounds=rounds_completed,
@@ -131,6 +176,19 @@ class FelixWorkflow:
                     "team_composition": [(a.agent_type, a.agent_id) for a in agents],
                 },
             )
+
+            self.emit_event(
+                EventType.WORKFLOW_COMPLETED,
+                {
+                    "rounds": rounds_completed,
+                    "converged": converged,
+                    "final_confidence": round(final_confidence, 4),
+                    "total_tokens": total_tokens,
+                    "elapsed_seconds": round(elapsed, 3),
+                },
+            )
+
+            return result
         finally:
             spoke_mgr.shutdown_all()
             hub.shutdown()
@@ -152,6 +210,9 @@ class FelixWorkflow:
                 spawn_time=spawn_time,
                 **kwargs,
             )
+            # Propagate event bus to each agent
+            if self._event_bus is not None:
+                agent.set_event_bus(self._event_bus)
             spoke_mgr.create_spoke(agent.agent_id, agent=agent)
             agents.append(agent)
 
@@ -246,10 +307,11 @@ def run_felix_workflow(
     provider: BaseProvider,
     task_description: str,
     context: str = "",
+    event_bus: Optional[EventBus] = None,
 ) -> WorkflowResult:
     """Run a Felix workflow in one call.
 
     Thin wrapper around :class:`FelixWorkflow` for simple use cases.
     """
-    workflow = FelixWorkflow(config, provider)
+    workflow = FelixWorkflow(config, provider, event_bus=event_bus)
     return workflow.run(task_description, context=context)

--- a/src/felix_agent_sdk/workflows/runner.py
+++ b/src/felix_agent_sdk/workflows/runner.py
@@ -54,8 +54,7 @@ class FelixWorkflow(EventEmitterMixin):
         self._config = config
         self._provider = provider
         self._factory = AgentFactory(provider, helix_config=config.helix_config)
-        if event_bus is not None:
-            self.set_event_bus(event_bus)
+        self.set_event_bus(event_bus)
 
     # ------------------------------------------------------------------
     # Public API

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,0 +1,320 @@
+"""Tests for the Felix event system — bus, types, and mixins."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from felix_agent_sdk.events import EventBus, EventType, FelixEvent
+from felix_agent_sdk.events.mixins import EventEmitterMixin
+
+
+# ---------------------------------------------------------------------------
+# FelixEvent
+# ---------------------------------------------------------------------------
+
+
+class TestFelixEvent:
+    def test_construction(self):
+        evt = FelixEvent(event_type="test.event", source="test")
+        assert evt.event_type == "test.event"
+        assert evt.source == "test"
+        assert evt.data == {}
+        assert isinstance(evt.timestamp, float)
+
+    def test_frozen(self):
+        evt = FelixEvent(event_type="x", source="y")
+        with pytest.raises(AttributeError):
+            evt.event_type = "z"  # type: ignore[misc]
+
+    def test_with_data(self):
+        evt = FelixEvent(event_type="x", source="y", data={"key": "val"})
+        assert evt.data == {"key": "val"}
+
+
+# ---------------------------------------------------------------------------
+# EventType enum
+# ---------------------------------------------------------------------------
+
+
+class TestEventType:
+    def test_agent_events(self):
+        assert EventType.AGENT_SPAWNED.value == "agent.spawned"
+        assert EventType.AGENT_COMPLETED.value == "agent.completed"
+        assert EventType.AGENT_FAILED.value == "agent.failed"
+
+    def test_workflow_events(self):
+        assert EventType.WORKFLOW_STARTED.value == "workflow.started"
+        assert EventType.WORKFLOW_ROUND_STARTED.value == "workflow.round.started"
+        assert EventType.WORKFLOW_COMPLETED.value == "workflow.completed"
+
+    def test_task_events(self):
+        assert EventType.TASK_STARTED.value == "task.started"
+        assert EventType.TASK_COMPLETED.value == "task.completed"
+
+    def test_string_enum(self):
+        # EventType values can be used as plain strings
+        assert EventType.WORKFLOW_STARTED == "workflow.started"
+
+
+# ---------------------------------------------------------------------------
+# EventBus — subscription and dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestEventBusSubscription:
+    def test_exact_match(self):
+        bus = EventBus()
+        received = []
+        bus.subscribe("workflow.started", received.append)
+
+        bus.emit(FelixEvent(event_type="workflow.started", source="test"))
+        bus.emit(FelixEvent(event_type="workflow.completed", source="test"))
+
+        assert len(received) == 1
+        assert received[0].event_type == "workflow.started"
+
+    def test_prefix_match(self):
+        bus = EventBus()
+        received = []
+        bus.subscribe("agent.*", received.append)
+
+        bus.emit(FelixEvent(event_type="agent.spawned", source="test"))
+        bus.emit(FelixEvent(event_type="agent.completed", source="test"))
+        bus.emit(FelixEvent(event_type="workflow.started", source="test"))
+
+        assert len(received) == 2
+        assert received[0].event_type == "agent.spawned"
+        assert received[1].event_type == "agent.completed"
+
+    def test_catch_all(self):
+        bus = EventBus()
+        received = []
+        bus.subscribe_all(received.append)
+
+        bus.emit(FelixEvent(event_type="agent.spawned", source="a"))
+        bus.emit(FelixEvent(event_type="workflow.started", source="b"))
+
+        assert len(received) == 2
+
+    def test_multiple_subscribers(self):
+        bus = EventBus()
+        r1, r2 = [], []
+        bus.subscribe("test.event", r1.append)
+        bus.subscribe("test.event", r2.append)
+
+        bus.emit(FelixEvent(event_type="test.event", source="test"))
+
+        assert len(r1) == 1
+        assert len(r2) == 1
+
+    def test_unsubscribe_exact(self):
+        bus = EventBus()
+        received = []
+        bus.subscribe("test.event", received.append)
+        bus.unsubscribe("test.event", received.append)
+
+        bus.emit(FelixEvent(event_type="test.event", source="test"))
+        assert len(received) == 0
+
+    def test_unsubscribe_prefix(self):
+        bus = EventBus()
+        received = []
+        bus.subscribe("agent.*", received.append)
+        bus.unsubscribe("agent.*", received.append)
+
+        bus.emit(FelixEvent(event_type="agent.spawned", source="test"))
+        assert len(received) == 0
+
+    def test_unsubscribe_all(self):
+        bus = EventBus()
+        received = []
+        bus.subscribe_all(received.append)
+        bus.unsubscribe_all(received.append)
+
+        bus.emit(FelixEvent(event_type="test.event", source="test"))
+        assert len(received) == 0
+
+
+# ---------------------------------------------------------------------------
+# EventBus — exception isolation
+# ---------------------------------------------------------------------------
+
+
+class TestEventBusExceptionIsolation:
+    def test_bad_callback_does_not_block_others(self):
+        bus = EventBus()
+        received = []
+
+        def bad_callback(event: FelixEvent) -> None:
+            raise RuntimeError("boom")
+
+        bus.subscribe("test.event", bad_callback)
+        bus.subscribe("test.event", received.append)
+
+        # Should not raise
+        bus.emit(FelixEvent(event_type="test.event", source="test"))
+
+        # Good callback still ran
+        assert len(received) == 1
+
+
+# ---------------------------------------------------------------------------
+# EventBus — history
+# ---------------------------------------------------------------------------
+
+
+class TestEventBusHistory:
+    def test_history_disabled_by_default(self):
+        bus = EventBus()
+        bus.emit(FelixEvent(event_type="test", source="test"))
+        assert len(bus.history) == 0
+
+    def test_history_enabled(self):
+        bus = EventBus()
+        bus.enable_history()
+
+        bus.emit(FelixEvent(event_type="a", source="test"))
+        bus.emit(FelixEvent(event_type="b", source="test"))
+
+        assert len(bus.history) == 2
+        assert bus.history[0].event_type == "a"
+
+    def test_history_returns_copy(self):
+        bus = EventBus()
+        bus.enable_history()
+        bus.emit(FelixEvent(event_type="x", source="test"))
+
+        h1 = bus.history
+        h2 = bus.history
+        assert h1 is not h2
+
+    def test_disable_clears_history(self):
+        bus = EventBus()
+        bus.enable_history()
+        bus.emit(FelixEvent(event_type="x", source="test"))
+        bus.enable_history(False)
+        assert len(bus.history) == 0
+
+
+# ---------------------------------------------------------------------------
+# EventBus — utilities
+# ---------------------------------------------------------------------------
+
+
+class TestEventBusUtilities:
+    def test_clear(self):
+        bus = EventBus()
+        bus.subscribe("test", lambda e: None)
+        bus.subscribe_all(lambda e: None)
+        bus.enable_history()
+        bus.emit(FelixEvent(event_type="test", source="test"))
+
+        bus.clear()
+        assert bus.subscriber_count == 0
+        assert len(bus.history) == 0
+
+    def test_subscriber_count(self):
+        bus = EventBus()
+        assert bus.subscriber_count == 0
+
+        bus.subscribe("a", lambda e: None)
+        bus.subscribe("b.*", lambda e: None)
+        bus.subscribe_all(lambda e: None)
+
+        assert bus.subscriber_count == 3
+
+    def test_thread_safety(self):
+        """Concurrent emit/subscribe should not crash."""
+        bus = EventBus()
+        received = []
+        bus.subscribe_all(received.append)
+
+        def emitter():
+            for _ in range(50):
+                bus.emit(FelixEvent(event_type="test", source="thread"))
+
+        threads = [threading.Thread(target=emitter) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(received) == 200
+
+
+# ---------------------------------------------------------------------------
+# EventEmitterMixin
+# ---------------------------------------------------------------------------
+
+
+class TestEventEmitterMixin:
+    def test_no_bus_is_silent(self):
+        class MyComponent(EventEmitterMixin):
+            pass
+
+        comp = MyComponent()
+        # Should not raise even with no bus
+        comp.emit_event("test.event", {"key": "val"})
+
+    def test_emit_with_bus(self):
+        class MyComponent(EventEmitterMixin):
+            pass
+
+        bus = EventBus()
+        received = []
+        bus.subscribe_all(received.append)
+
+        comp = MyComponent()
+        comp.set_event_bus(bus)
+        comp.emit_event("test.event", {"key": "val"})
+
+        assert len(received) == 1
+        assert received[0].event_type == "test.event"
+        assert received[0].data == {"key": "val"}
+
+    def test_default_source(self):
+        class MyComponent(EventEmitterMixin):
+            pass
+
+        bus = EventBus()
+        received = []
+        bus.subscribe_all(received.append)
+
+        comp = MyComponent()
+        comp.set_event_bus(bus)
+        comp.emit_event("test.event")
+
+        assert received[0].source == "MyComponent"
+
+    def test_custom_source(self):
+        class MyComponent(EventEmitterMixin):
+            pass
+
+        bus = EventBus()
+        received = []
+        bus.subscribe_all(received.append)
+
+        comp = MyComponent()
+        comp.set_event_bus(bus)
+        comp.emit_event("test.event", source="custom:src")
+
+        assert received[0].source == "custom:src"
+
+    def test_detach_bus(self):
+        class MyComponent(EventEmitterMixin):
+            pass
+
+        bus = EventBus()
+        received = []
+        bus.subscribe_all(received.append)
+
+        comp = MyComponent()
+        comp.set_event_bus(bus)
+        comp.emit_event("a")
+        comp.set_event_bus(None)
+        comp.emit_event("b")
+
+        assert len(received) == 1

--- a/tests/unit/test_workflow_events.py
+++ b/tests/unit/test_workflow_events.py
@@ -1,0 +1,172 @@
+"""Tests verifying event emission from FelixWorkflow."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from felix_agent_sdk import WorkflowConfig, run_felix_workflow
+from felix_agent_sdk.events import EventBus, EventType, FelixEvent
+from felix_agent_sdk.providers.base import BaseProvider
+from felix_agent_sdk.providers.types import CompletionResult
+
+
+def _make_mock_provider() -> BaseProvider:
+    """Provider that returns canned responses."""
+    provider = MagicMock(spec=BaseProvider)
+    counter = [0]
+    responses = [
+        "Research finding about renewable energy.",
+        "Analysis of market trends and data.",
+        "Critique: findings are sound but need more evidence.",
+        "Synthesis of all findings into a coherent report.",
+    ]
+
+    def _complete(messages, **kwargs):
+        idx = counter[0] % len(responses)
+        counter[0] += 1
+        return CompletionResult(
+            content=responses[idx],
+            model="mock",
+            usage={"prompt_tokens": 40, "completion_tokens": 30, "total_tokens": 70},
+        )
+
+    provider.complete.side_effect = _complete
+    provider.count_tokens.return_value = 40
+    return provider
+
+
+class TestWorkflowEventSequence:
+    """Verify the exact sequence of events emitted during a workflow run."""
+
+    def test_full_event_sequence(self):
+        bus = EventBus()
+        bus.enable_history()
+
+        provider = _make_mock_provider()
+        config = WorkflowConfig(max_rounds=2)
+
+        run_felix_workflow(
+            config, provider, "Test task", event_bus=bus
+        )
+
+        events = bus.history
+        types = [e.event_type for e in events]
+
+        # Must start with workflow.started
+        assert types[0] == EventType.WORKFLOW_STARTED
+
+        # Must end with workflow.completed
+        assert types[-1] == EventType.WORKFLOW_COMPLETED
+
+        # Must contain round starts and completions
+        assert EventType.WORKFLOW_ROUND_STARTED in types
+        assert EventType.WORKFLOW_ROUND_COMPLETED in types
+
+        # Must contain task processing events
+        assert EventType.TASK_STARTED in types
+        assert EventType.TASK_COMPLETED in types
+
+        # Must contain synthesis
+        assert EventType.WORKFLOW_SYNTHESIS_STARTED in types
+
+    def test_round_events_bracket_tasks(self):
+        """Round start/end should bracket the task events within that round."""
+        bus = EventBus()
+        bus.enable_history()
+
+        provider = _make_mock_provider()
+        config = WorkflowConfig(max_rounds=1)
+
+        run_felix_workflow(config, provider, "Test", event_bus=bus)
+
+        events = bus.history
+        types = [e.event_type for e in events]
+
+        round_start_idx = types.index(EventType.WORKFLOW_ROUND_STARTED)
+        round_end_idx = types.index(EventType.WORKFLOW_ROUND_COMPLETED)
+        task_start_idx = types.index(EventType.TASK_STARTED)
+        task_end_idx = types.index(EventType.TASK_COMPLETED)
+
+        assert round_start_idx < task_start_idx
+        assert task_end_idx < round_end_idx
+
+    def test_workflow_started_has_metadata(self):
+        bus = EventBus()
+        bus.enable_history()
+
+        config = WorkflowConfig(max_rounds=1)
+        run_felix_workflow(config, _make_mock_provider(), "My task", event_bus=bus)
+
+        started = [e for e in bus.history if e.event_type == EventType.WORKFLOW_STARTED]
+        assert len(started) == 1
+        assert started[0].data["task"] == "My task"
+        assert started[0].data["max_rounds"] == 1
+        assert started[0].data["agents_count"] == 3  # default team
+
+    def test_workflow_completed_has_metadata(self):
+        bus = EventBus()
+        bus.enable_history()
+
+        config = WorkflowConfig(max_rounds=1)
+        run_felix_workflow(config, _make_mock_provider(), "Task", event_bus=bus)
+
+        completed = [e for e in bus.history if e.event_type == EventType.WORKFLOW_COMPLETED]
+        assert len(completed) == 1
+        assert "rounds" in completed[0].data
+        assert "final_confidence" in completed[0].data
+        assert "total_tokens" in completed[0].data
+        assert "elapsed_seconds" in completed[0].data
+
+    def test_task_completed_has_agent_details(self):
+        bus = EventBus()
+        bus.enable_history()
+
+        config = WorkflowConfig(max_rounds=1)
+        run_felix_workflow(config, _make_mock_provider(), "Task", event_bus=bus)
+
+        task_events = [e for e in bus.history if e.event_type == EventType.TASK_COMPLETED]
+        assert len(task_events) > 0
+
+        first = task_events[0]
+        assert "task_id" in first.data
+        assert "agent_type" in first.data
+        assert "confidence" in first.data
+        assert "temperature" in first.data
+        assert "tokens" in first.data
+
+    def test_no_bus_no_crash(self):
+        """Workflow works fine without an event bus."""
+        config = WorkflowConfig(max_rounds=1)
+        result = run_felix_workflow(config, _make_mock_provider(), "Task")
+        assert result.synthesis is not None
+
+    def test_subscriber_receives_events_live(self):
+        """Verify that subscribers are called during the workflow, not after."""
+        bus = EventBus()
+        received_during = []
+
+        def on_round_start(event: FelixEvent):
+            received_during.append(event.event_type)
+
+        bus.subscribe(EventType.WORKFLOW_ROUND_STARTED, on_round_start)
+
+        config = WorkflowConfig(max_rounds=2)
+        run_felix_workflow(config, _make_mock_provider(), "Task", event_bus=bus)
+
+        assert len(received_during) == 2
+
+    def test_event_count_scales_with_rounds(self):
+        """More rounds = more events."""
+        bus1 = EventBus()
+        bus1.enable_history()
+        bus2 = EventBus()
+        bus2.enable_history()
+
+        run_felix_workflow(
+            WorkflowConfig(max_rounds=1), _make_mock_provider(), "T", event_bus=bus1
+        )
+        run_felix_workflow(
+            WorkflowConfig(max_rounds=3), _make_mock_provider(), "T", event_bus=bus2
+        )
+
+        assert len(bus2.history) > len(bus1.history)


### PR DESCRIPTION
## Summary

Foundation for Phase 2 observability. All subsequent PRs build on this.

- **EventBus** — sync pub/sub with exact, prefix (`"agent.*"`), and catch-all subscriptions. Thread-safe, exception-isolated.
- **FelixEvent** — frozen dataclass with event_type, source, data, timestamp.
- **EventType** — enum covering agent, workflow, task, message, stream, and spawn events.
- **EventEmitterMixin** — opt-in mixin for any class to emit events. Zero overhead when no bus attached.
- **Wired into**: FelixWorkflow (6 lifecycle events), LLMAgent (task start/complete), CentralPost (lifecycle bridge)
- All event_bus params are optional. Existing API unchanged.

## Test plan
- [x] 35 new tests (bus, types, mixin, workflow event sequence)
- [x] 698 total tests passing
- [x] `ruff check src/` clean
- [x] No breaking changes to existing 26 public exports

Contributes to #9