### PR TITLE
feat: add reusable terminal helix visualizer module

### DIFF
--- a/src/felix_agent_sdk/__init__.py
+++ b/src/felix_agent_sdk/__init__.py
@@ -38,6 +38,7 @@ from felix_agent_sdk.streaming import StreamEvent, StreamHandler
 from felix_agent_sdk.tokens import TokenBudget
 from felix_agent_sdk.utils import configure_logging
 from felix_agent_sdk.workflows import FelixWorkflow, WorkflowConfig, run_felix_workflow
+from felix_agent_sdk.visualization import HelixVisualizer
 
 __all__ = [
     "__version__",
@@ -84,4 +85,6 @@ __all__ = [
     "configure_logging",
     # Tokens
     "TokenBudget",
+    # Visualization
+    "HelixVisualizer",
 ]

--- a/src/felix_agent_sdk/cli/main.py
+++ b/src/felix_agent_sdk/cli/main.py
@@ -24,7 +24,8 @@ def main(argv: list[str] | None = None) -> int:
     init_p = subparsers.add_parser("init", help="Scaffold a new Felix project")
     init_p.add_argument("name", help="Project directory name")
     init_p.add_argument(
-        "--template", "-t",
+        "--template",
+        "-t",
         default="research",
         choices=["research", "analysis", "review"],
         help="Workflow template (default: research)",
@@ -35,6 +36,9 @@ def main(argv: list[str] | None = None) -> int:
     run_p.add_argument("config", help="Path to felix.yaml")
     run_p.add_argument("--provider", "-p", default=None, help="Override provider name")
     run_p.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
+    run_p.add_argument(
+        "--visualize", "-V", action="store_true", help="Show live helix visualization"
+    )
 
     # --- version ---
     subparsers.add_parser("version", help="Show SDK version")
@@ -49,7 +53,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "run":
         from felix_agent_sdk.cli.run_command import run_workflow
 
-        return run_workflow(args.config, args.provider, args.verbose)
+        return run_workflow(args.config, args.provider, args.verbose, args.visualize)
 
     if args.command == "version":
         from felix_agent_sdk._version import __version__

--- a/src/felix_agent_sdk/cli/run_command.py
+++ b/src/felix_agent_sdk/cli/run_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from contextlib import nullcontext
 
 from felix_agent_sdk.cli.yaml_loader import load_workflow_yaml
 from felix_agent_sdk.providers.base import BaseProvider
@@ -10,8 +11,19 @@ from felix_agent_sdk.utils.logging import FelixLogConfig, configure_logging
 from felix_agent_sdk.workflows.runner import run_felix_workflow
 
 
-def run_workflow(config_path: str, provider_name: str | None, verbose: bool) -> int:
+def run_workflow(
+    config_path: str,
+    provider_name: str | None,
+    verbose: bool,
+    visualize: bool = False,
+) -> int:
     """Load a YAML config, resolve the provider, and run the workflow.
+
+    Args:
+        config_path: Path to the ``felix.yaml`` config file.
+        provider_name: Override provider name (``None`` = use config).
+        verbose: Enable debug logging.
+        visualize: Show live helix visualization during the run.
 
     Returns:
         Exit code (0 = success, 1 = error).
@@ -40,17 +52,39 @@ def run_workflow(config_path: str, provider_name: str | None, verbose: bool) -> 
         )
         return 1
 
-    print("Running Felix workflow...")
-    print(f"  Provider: {effective_provider or 'auto'}")
-    print(f"  Task: {task[:80]}{'...' if len(task) > 80 else ''}")
-    print(f"  Team: {len(config.team_composition)} agents, {config.max_rounds} rounds")
-    print()
+    # Optional visualization
+    event_bus = None
+    viz = None
 
-    try:
-        result = run_felix_workflow(config, provider, task)
-    except Exception as e:
-        print(f"Error during workflow: {e}", file=sys.stderr)
-        return 1
+    if visualize:
+        from felix_agent_sdk.events import EventBus
+        from felix_agent_sdk.visualization import HelixVisualizer
+
+        event_bus = EventBus()
+        helix = config.helix_config.to_geometry()
+        viz = HelixVisualizer(helix)
+        viz.attach_event_bus(event_bus)
+
+        def _on_round_complete(event):  # type: ignore[no-untyped-def]
+            viz.render(tick=event.data.get("round", 0))
+
+        event_bus.subscribe("workflow.round.completed", _on_round_complete)
+    else:
+        print("Running Felix workflow...")
+        print(f"  Provider: {effective_provider or 'auto'}")
+        print(f"  Task: {task[:80]}{'...' if len(task) > 80 else ''}")
+        print(f"  Team: {len(config.team_composition)} agents, {config.max_rounds} rounds")
+        print()
+
+    ctx = viz.live() if viz else nullcontext()
+    with ctx:
+        try:
+            result = run_felix_workflow(config, provider, task, event_bus=event_bus)
+        except Exception as e:
+            print(f"Error during workflow: {e}", file=sys.stderr)
+            return 1
+        if viz:
+            viz.render()
 
     print("=== Result ===")
     print(f"Rounds: {result.total_rounds}")

--- a/src/felix_agent_sdk/visualization/__init__.py
+++ b/src/felix_agent_sdk/visualization/__init__.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 from felix_agent_sdk.visualization.helix_visualizer import (
     AgentDisplayState,
     HelixVisualizer,
+    VisualizerStreamHandler,
 )
 
 __all__ = [
     "AgentDisplayState",
     "HelixVisualizer",
+    "VisualizerStreamHandler",
 ]

--- a/src/felix_agent_sdk/visualization/__init__.py
+++ b/src/felix_agent_sdk/visualization/__init__.py
@@ -1,0 +1,18 @@
+"""Felix visualization module — terminal-based helix rendering.
+
+Provides a reusable ASCII visualizer that renders agents progressing down
+a 3D helix in real time, showing phase boundaries, confidence levels, and
+per-agent status in a sidebar panel.
+"""
+
+from __future__ import annotations
+
+from felix_agent_sdk.visualization.helix_visualizer import (
+    AgentDisplayState,
+    HelixVisualizer,
+)
+
+__all__ = [
+    "AgentDisplayState",
+    "HelixVisualizer",
+]

--- a/src/felix_agent_sdk/visualization/helix_visualizer.py
+++ b/src/felix_agent_sdk/visualization/helix_visualizer.py
@@ -1,0 +1,485 @@
+"""Reusable terminal helix visualizer — renders agents spiralling from exploration to synthesis.
+
+Draws a side-view cross-section of the helix in the terminal, showing each
+agent's position, phase, confidence, and status in real time.  Adapted from
+the demo visualizer in ``examples/05_deep_research_live/helix_visualizer.py``
+and generalised for library-wide reuse.
+
+No external dependencies beyond the Felix SDK and the Python stdlib.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Optional
+
+from felix_agent_sdk.core.helix import ANALYSIS_END, EXPLORATION_END, HelixGeometry
+from felix_agent_sdk.visualization.terminal import (
+    BOLD,
+    DIM,
+    PHASE_COLORS,
+    RESET,
+    clear_screen,
+    colorize,
+    hide_cursor,
+    progress_bar,
+    show_cursor,
+)
+
+# ---------------------------------------------------------------------------
+# Colour-name → ANSI-code mapping
+# ---------------------------------------------------------------------------
+
+_COLOR_MAP: Dict[str, str] = {
+    "cyan": "\033[96m",
+    "yellow": "\033[93m",
+    "green": "\033[92m",
+    "red": "\033[91m",
+    "magenta": "\033[95m",
+    "white": "\033[97m",
+}
+
+# Phase boundary glyphs
+_PHASE_ICONS: Dict[str, str] = {
+    "exploration": "~",
+    "analysis": "=",
+    "synthesis": "#",
+}
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AgentDisplayState:
+    """Display state for a registered agent.
+
+    Attributes:
+        agent_id: Unique agent identifier.
+        label: Two-character short label rendered on the helix (e.g. ``"RM"``).
+        color: ANSI escape code for this agent's colour.
+        progress: Parametric position ``t`` in ``[0, 1]``.
+        confidence: Agent confidence in ``[0, 1]``.
+        phase: Current workflow phase name.
+        status: Short free-text status string.
+    """
+
+    agent_id: str
+    label: str
+    color: str
+    progress: float = 0.0
+    confidence: float = 0.0
+    phase: str = "exploration"
+    status: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Visualizer
+# ---------------------------------------------------------------------------
+
+
+class HelixVisualizer:
+    """Renders an ASCII helix with live agent positions in the terminal.
+
+    Usage::
+
+        from felix_agent_sdk.core.helix import HelixConfig
+        from felix_agent_sdk.visualization import HelixVisualizer
+
+        helix = HelixConfig.default().to_geometry()
+        viz = HelixVisualizer(helix)
+        viz.register_agent("rm", label="RM", color="green")
+        viz.update("rm", progress=0.3, confidence=0.7, phase="exploration")
+        with viz.live() as v:
+            v.render(tick=1, day=1)
+
+    Args:
+        helix: A ``HelixGeometry`` that defines the spiral shape.
+        title: Header title shown above the helix.
+        width: Character width of the helix canvas.
+        height: Character height of the helix canvas.
+        sidebar_width: Character width of the sidebar agent panel.
+    """
+
+    def __init__(
+        self,
+        helix: HelixGeometry,
+        *,
+        title: str = "F E L I X",
+        width: int = 50,
+        height: int = 28,
+        sidebar_width: int = 40,
+    ) -> None:
+        self._helix = helix
+        self._title = title
+        self._width = width
+        self._height = height
+        self._sidebar_width = sidebar_width
+        self._agents: Dict[str, AgentDisplayState] = {}
+        self._frame: int = 0
+
+    # ------------------------------------------------------------------
+    # Registration & update
+    # ------------------------------------------------------------------
+
+    def register_agent(
+        self,
+        agent_id: str,
+        label: str,
+        color: str = "cyan",
+    ) -> None:
+        """Register an agent for display.
+
+        Args:
+            agent_id: Unique identifier for this agent.
+            label: Two-character label rendered on the helix (e.g. ``"RM"``).
+            color: Colour name — one of ``'cyan'``, ``'yellow'``, ``'green'``,
+                ``'red'``, ``'magenta'``, ``'white'``.
+        """
+        ansi = _COLOR_MAP.get(color, _COLOR_MAP["cyan"])
+        self._agents[agent_id] = AgentDisplayState(
+            agent_id=agent_id,
+            label=label,
+            color=ansi,
+        )
+
+    def update(
+        self,
+        agent_id: str,
+        progress: float,
+        confidence: float,
+        phase: str = "",
+        status: str = "",
+    ) -> None:
+        """Update an agent's display state.
+
+        Args:
+            agent_id: Must match a previously registered agent.
+            progress: Parametric position ``t`` in ``[0, 1]``.
+            confidence: Agent confidence in ``[0, 1]``.
+            phase: Phase name (``"exploration"``, ``"analysis"``,
+                ``"synthesis"``). Auto-derived from *progress* if empty.
+            status: Optional short status string for the sidebar.
+
+        Raises:
+            KeyError: If *agent_id* was not registered.
+        """
+        if agent_id not in self._agents:
+            raise KeyError(f"Agent {agent_id!r} is not registered")
+        agent = self._agents[agent_id]
+        agent.progress = progress
+        agent.confidence = confidence
+        if phase:
+            agent.phase = phase
+        else:
+            # Auto-derive phase from progress
+            if progress < EXPLORATION_END:
+                agent.phase = "exploration"
+            elif progress < ANALYSIS_END:
+                agent.phase = "analysis"
+            else:
+                agent.phase = "synthesis"
+        if status:
+            agent.status = status
+
+    # ------------------------------------------------------------------
+    # Rendering — public
+    # ------------------------------------------------------------------
+
+    def render(
+        self,
+        *,
+        tick: int = 0,
+        day: int = 0,
+        extra_info: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Clear the terminal and print the current frame.
+
+        Args:
+            tick: Current simulation tick for the header.
+            day: Current simulation day for the header.
+            extra_info: Arbitrary key-value pairs shown in the header.
+        """
+        sys.stdout.write(clear_screen())
+        sys.stdout.write(
+            self.render_to_string(tick=tick, day=day, extra_info=extra_info)
+        )
+        sys.stdout.flush()
+
+    def render_to_string(
+        self,
+        *,
+        tick: int = 0,
+        day: int = 0,
+        extra_info: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Return the current frame as a string without writing to stdout.
+
+        Args:
+            tick: Current simulation tick for the header.
+            day: Current simulation day for the header.
+            extra_info: Arbitrary key-value pairs shown in the header.
+
+        Returns:
+            The rendered frame as a multi-line string.
+        """
+        self._frame += 1
+        canvas = self._blank_canvas()
+        self._draw_helix_backbone(canvas)
+        self._draw_phase_boundaries(canvas)
+
+        agents = list(self._agents.values())
+        for agent in sorted(agents, key=lambda a: a.progress):
+            self._place_agent(canvas, agent)
+
+        sidebar = self._build_sidebar(agents)
+        lines = self._merge(canvas, sidebar)
+        header = self._build_header(tick, day, extra_info)
+        footer = self._build_footer(agents)
+        return "\n".join([header, *lines, footer, ""])
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def live(self) -> Iterator[HelixVisualizer]:
+        """Context manager that hides the cursor on entry and restores it on exit.
+
+        Yields:
+            This ``HelixVisualizer`` instance.
+        """
+        try:
+            sys.stdout.write(hide_cursor())
+            sys.stdout.flush()
+            yield self
+        finally:
+            sys.stdout.write(show_cursor())
+            sys.stdout.flush()
+
+    # ------------------------------------------------------------------
+    # Canvas internals
+    # ------------------------------------------------------------------
+
+    def _blank_canvas(self) -> List[List[str]]:
+        """Create an empty canvas (list of character rows)."""
+        return [[" "] * self._width for _ in range(self._height)]
+
+    def _draw_helix_backbone(self, canvas: List[List[str]]) -> None:
+        """Draw the spiral backbone as phase-coloured glyphs on the canvas."""
+        centre = self._width // 2
+        max_radius_chars = (self._width // 2) - 2
+
+        for row in range(self._height):
+            t = row / max(self._height - 1, 1)
+
+            # Radius fraction normalised to [0, 1]
+            z = self._helix.height * (1.0 - t)
+            radius = self._helix.get_radius(z)
+            max_r = self._helix.get_radius(self._helix.height)  # top radius
+            r_frac = radius / max_r if max_r > 0 else 0
+
+            # Angle with slow animation offset
+            angle = self._helix.get_angle_at_t(t) + self._frame * 0.05
+            x_offset = int(r_frac * max_radius_chars * math.cos(angle))
+            col = centre + x_offset
+
+            # Phase-based glyph and colour
+            if t < EXPLORATION_END:
+                glyph = _PHASE_ICONS["exploration"]
+                colour = PHASE_COLORS["exploration"]
+            elif t < ANALYSIS_END:
+                glyph = _PHASE_ICONS["analysis"]
+                colour = PHASE_COLORS["analysis"]
+            else:
+                glyph = _PHASE_ICONS["synthesis"]
+                colour = PHASE_COLORS["synthesis"]
+
+            if 0 <= col < self._width:
+                canvas[row][col] = colorize(DIM + colour, glyph)
+
+    def _draw_phase_boundaries(self, canvas: List[List[str]]) -> None:
+        """Draw dashed horizontal lines at phase boundaries with labels."""
+        explore_row = int(EXPLORATION_END * (self._height - 1))
+        analysis_row = int(ANALYSIS_END * (self._height - 1))
+
+        for col in range(self._width):
+            if canvas[explore_row][col].strip() == "":
+                canvas[explore_row][col] = colorize(
+                    DIM + PHASE_COLORS["exploration"], "-"
+                )
+            if canvas[analysis_row][col].strip() == "":
+                canvas[analysis_row][col] = colorize(
+                    DIM + PHASE_COLORS["analysis"], "-"
+                )
+
+        # Phase labels centred on the boundary rows
+        explore_label = " EXPLORATION "
+        analysis_label = " ANALYSIS "
+        e_start = max(0, (self._width - len(explore_label)) // 2)
+        a_start = max(0, (self._width - len(analysis_label)) // 2)
+
+        for i, ch in enumerate(explore_label):
+            c = e_start + i
+            if 0 <= c < self._width:
+                canvas[explore_row][c] = colorize(
+                    BOLD + PHASE_COLORS["exploration"], ch
+                )
+
+        for i, ch in enumerate(analysis_label):
+            c = a_start + i
+            if 0 <= c < self._width:
+                canvas[analysis_row][c] = colorize(
+                    BOLD + PHASE_COLORS["analysis"], ch
+                )
+
+    def _place_agent(
+        self, canvas: List[List[str]], agent: AgentDisplayState
+    ) -> None:
+        """Place an agent label on the canvas at its helix position."""
+        t = agent.progress
+        row = int(t * (self._height - 1))
+        row = max(0, min(self._height - 1, row))
+
+        centre = self._width // 2
+        max_radius_chars = (self._width // 2) - 2
+
+        z = self._helix.height * (1.0 - t)
+        radius = self._helix.get_radius(z)
+        max_r = self._helix.get_radius(self._helix.height)
+        r_frac = radius / max_r if max_r > 0 else 0
+
+        angle = self._helix.get_angle_at_t(t)
+        x_offset = int(r_frac * max_radius_chars * math.cos(angle))
+        col = centre + x_offset
+        col = max(1, min(self._width - 2, col))
+
+        # Confidence-based intensity
+        intensity = BOLD if agent.confidence > 0.6 else ""
+        label_str = f"[{agent.label}]"
+        canvas[row][col] = colorize(intensity + agent.color, label_str)
+
+        # Trim overlap from adjacent cells consumed by the multi-char label
+        if col + 1 < self._width:
+            canvas[row][col + 1] = ""
+        if col + 2 < self._width:
+            canvas[row][col + 2] = ""
+
+    # ------------------------------------------------------------------
+    # Sidebar
+    # ------------------------------------------------------------------
+
+    def _build_sidebar(self, agents: List[AgentDisplayState]) -> List[str]:
+        """Build the right-hand agent detail panel."""
+        lines: List[str] = []
+        lines.append(colorize(BOLD, " Agents"))
+        lines.append(" " + "-" * (self._sidebar_width - 2))
+
+        for agent in agents:
+            phase_colour = PHASE_COLORS.get(agent.phase, RESET)
+
+            # Agent header
+            name = f"[{agent.label}] {agent.agent_id}"
+            lines.append(f" {colorize(BOLD + agent.color, name)}")
+
+            # Progress bar
+            bar_width = self._sidebar_width - 14
+            bar = progress_bar(agent.progress, bar_width)
+            pct = f"{agent.progress * 100:5.1f}%"
+            lines.append(f"   {colorize(agent.color, bar)} {pct}")
+
+            # Confidence + phase
+            conf_str = f"conf:{agent.confidence:.2f}"
+            phase_str = agent.phase[:5].upper()
+            lines.append(
+                f"   {conf_str}  {colorize(phase_colour, phase_str)}"
+            )
+
+            # Optional status line
+            if agent.status:
+                preview = agent.status[: self._sidebar_width - 6]
+                if len(agent.status) > self._sidebar_width - 6:
+                    preview = preview[: self._sidebar_width - 9] + "..."
+                lines.append(f"   {colorize(DIM, preview)}")
+
+            lines.append("")
+
+        # Pad to canvas height
+        while len(lines) < self._height:
+            lines.append("")
+
+        return lines[: self._height]
+
+    # ------------------------------------------------------------------
+    # Header / footer
+    # ------------------------------------------------------------------
+
+    def _build_header(
+        self,
+        tick: int,
+        day: int,
+        extra_info: Optional[Dict[str, Any]],
+    ) -> str:
+        """Build the header block above the helix canvas."""
+        parts = [f"  {colorize(BOLD, self._title)}"]
+        if tick or day:
+            parts.append(f"Tick {tick}")
+            parts.append(f"Day {day}")
+        header_text = "  |  ".join(parts)
+
+        # Extra info key-value pairs
+        extra_line = ""
+        if extra_info:
+            kv = "  ".join(f"{k}={v}" for k, v in extra_info.items())
+            extra_line = f"\n  {colorize(DIM, kv)}"
+
+        separator = "  " + "\u2550" * (self._width + self._sidebar_width + 3)
+
+        phase_legend = (
+            f"  Phases: {colorize(PHASE_COLORS['exploration'], '~ EXPLORATION')}  "
+            f"{colorize(PHASE_COLORS['analysis'], '= ANALYSIS')}  "
+            f"{colorize(PHASE_COLORS['synthesis'], '# SYNTHESIS')}"
+        )
+        return f"\n{header_text}{extra_line}\n{separator}\n{phase_legend}\n"
+
+    def _build_footer(self, agents: List[AgentDisplayState]) -> str:
+        """Build the footer with team confidence bar."""
+        separator = "  " + "\u2550" * (self._width + self._sidebar_width + 3)
+
+        avg_conf = (
+            sum(a.confidence for a in agents) / len(agents) if agents else 0.0
+        )
+        bar = progress_bar(avg_conf, 30)
+
+        if avg_conf >= 0.75:
+            conf_colour = PHASE_COLORS["synthesis"]  # green
+        elif avg_conf >= 0.5:
+            conf_colour = PHASE_COLORS["analysis"]  # yellow
+        else:
+            conf_colour = "\033[91m"  # red
+
+        conf_line = (
+            f"  Team Confidence: {colorize(conf_colour, bar)} "
+            f"{colorize(BOLD + conf_colour, f'{avg_conf:.1%}')}"
+        )
+        return f"{separator}\n{conf_line}"
+
+    # ------------------------------------------------------------------
+    # Merge
+    # ------------------------------------------------------------------
+
+    def _merge(
+        self, canvas: List[List[str]], sidebar: List[str]
+    ) -> List[str]:
+        """Merge the helix canvas rows with the sidebar rows."""
+        lines: List[str] = []
+        for row_idx in range(self._height):
+            canvas_line = "".join(canvas[row_idx])
+            side = sidebar[row_idx] if row_idx < len(sidebar) else ""
+            lines.append(f"  {canvas_line} \u2502{side}")
+        return lines

--- a/src/felix_agent_sdk/visualization/helix_visualizer.py
+++ b/src/felix_agent_sdk/visualization/helix_visualizer.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Iterator, List, Optional
 from felix_agent_sdk.core.helix import ANALYSIS_END, EXPLORATION_END, HelixGeometry
 from felix_agent_sdk.visualization.terminal import (
     BOLD,
+    COLOR_MAP,
     DIM,
     PHASE_COLORS,
     RESET,
@@ -28,19 +29,6 @@ from felix_agent_sdk.visualization.terminal import (
     progress_bar,
     show_cursor,
 )
-
-# ---------------------------------------------------------------------------
-# Colour-name → ANSI-code mapping
-# ---------------------------------------------------------------------------
-
-_COLOR_MAP: Dict[str, str] = {
-    "cyan": "\033[96m",
-    "yellow": "\033[93m",
-    "green": "\033[92m",
-    "red": "\033[91m",
-    "magenta": "\033[95m",
-    "white": "\033[97m",
-}
 
 # Phase boundary glyphs
 _PHASE_ICONS: Dict[str, str] = {
@@ -141,7 +129,7 @@ class HelixVisualizer:
             color: Colour name — one of ``'cyan'``, ``'yellow'``, ``'green'``,
                 ``'red'``, ``'magenta'``, ``'white'``.
         """
-        ansi = _COLOR_MAP.get(color, _COLOR_MAP["cyan"])
+        ansi = COLOR_MAP.get(color, COLOR_MAP["cyan"])
         self._agents[agent_id] = AgentDisplayState(
             agent_id=agent_id,
             label=label,

--- a/src/felix_agent_sdk/visualization/helix_visualizer.py
+++ b/src/felix_agent_sdk/visualization/helix_visualizer.py
@@ -206,9 +206,7 @@ class HelixVisualizer:
             extra_info: Arbitrary key-value pairs shown in the header.
         """
         sys.stdout.write(clear_screen())
-        sys.stdout.write(
-            self.render_to_string(tick=tick, day=day, extra_info=extra_info)
-        )
+        sys.stdout.write(self.render_to_string(tick=tick, day=day, extra_info=extra_info))
         sys.stdout.flush()
 
     def render_to_string(
@@ -310,13 +308,9 @@ class HelixVisualizer:
 
         for col in range(self._width):
             if canvas[explore_row][col].strip() == "":
-                canvas[explore_row][col] = colorize(
-                    DIM + PHASE_COLORS["exploration"], "-"
-                )
+                canvas[explore_row][col] = colorize(DIM + PHASE_COLORS["exploration"], "-")
             if canvas[analysis_row][col].strip() == "":
-                canvas[analysis_row][col] = colorize(
-                    DIM + PHASE_COLORS["analysis"], "-"
-                )
+                canvas[analysis_row][col] = colorize(DIM + PHASE_COLORS["analysis"], "-")
 
         # Phase labels centred on the boundary rows
         explore_label = " EXPLORATION "
@@ -327,20 +321,14 @@ class HelixVisualizer:
         for i, ch in enumerate(explore_label):
             c = e_start + i
             if 0 <= c < self._width:
-                canvas[explore_row][c] = colorize(
-                    BOLD + PHASE_COLORS["exploration"], ch
-                )
+                canvas[explore_row][c] = colorize(BOLD + PHASE_COLORS["exploration"], ch)
 
         for i, ch in enumerate(analysis_label):
             c = a_start + i
             if 0 <= c < self._width:
-                canvas[analysis_row][c] = colorize(
-                    BOLD + PHASE_COLORS["analysis"], ch
-                )
+                canvas[analysis_row][c] = colorize(BOLD + PHASE_COLORS["analysis"], ch)
 
-    def _place_agent(
-        self, canvas: List[List[str]], agent: AgentDisplayState
-    ) -> None:
+    def _place_agent(self, canvas: List[List[str]], agent: AgentDisplayState) -> None:
         """Place an agent label on the canvas at its helix position."""
         t = agent.progress
         row = int(t * (self._height - 1))
@@ -396,9 +384,7 @@ class HelixVisualizer:
             # Confidence + phase
             conf_str = f"conf:{agent.confidence:.2f}"
             phase_str = agent.phase[:5].upper()
-            lines.append(
-                f"   {conf_str}  {colorize(phase_colour, phase_str)}"
-            )
+            lines.append(f"   {conf_str}  {colorize(phase_colour, phase_str)}")
 
             # Optional status line
             if agent.status:
@@ -451,9 +437,7 @@ class HelixVisualizer:
         """Build the footer with team confidence bar."""
         separator = "  " + "\u2550" * (self._width + self._sidebar_width + 3)
 
-        avg_conf = (
-            sum(a.confidence for a in agents) / len(agents) if agents else 0.0
-        )
+        avg_conf = sum(a.confidence for a in agents) / len(agents) if agents else 0.0
         bar = progress_bar(avg_conf, 30)
 
         if avg_conf >= 0.75:
@@ -473,9 +457,7 @@ class HelixVisualizer:
     # Merge
     # ------------------------------------------------------------------
 
-    def _merge(
-        self, canvas: List[List[str]], sidebar: List[str]
-    ) -> List[str]:
+    def _merge(self, canvas: List[List[str]], sidebar: List[str]) -> List[str]:
         """Merge the helix canvas rows with the sidebar rows."""
         lines: List[str] = []
         for row_idx in range(self._height):

--- a/src/felix_agent_sdk/visualization/helix_visualizer.py
+++ b/src/felix_agent_sdk/visualization/helix_visualizer.py
@@ -17,6 +17,11 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterator, List, Optional
 
 from felix_agent_sdk.core.helix import ANALYSIS_END, EXPLORATION_END, HelixGeometry
+from felix_agent_sdk.events.bus import EventBus
+from felix_agent_sdk.events.types import EventType, FelixEvent
+from felix_agent_sdk.spawning.confidence_monitor import ConfidenceMonitor
+from felix_agent_sdk.streaming.handler import StreamHandler
+from felix_agent_sdk.streaming.types import StreamEvent
 from felix_agent_sdk.visualization.terminal import (
     BOLD,
     COLOR_MAP,
@@ -35,6 +40,14 @@ _PHASE_ICONS: Dict[str, str] = {
     "exploration": "~",
     "analysis": "=",
     "synthesis": "#",
+}
+
+# Agent-type → colour-name mapping for auto-registration from events
+_AGENT_TYPE_COLORS: Dict[str, str] = {
+    "research": "cyan",
+    "analysis": "yellow",
+    "critic": "magenta",
+    "synthesis": "green",
 }
 
 
@@ -110,6 +123,8 @@ class HelixVisualizer:
         self._sidebar_width = sidebar_width
         self._agents: Dict[str, AgentDisplayState] = {}
         self._frame: int = 0
+        self._event_bus: Optional[EventBus] = None
+        self._monitor: Optional[ConfidenceMonitor] = None
 
     # ------------------------------------------------------------------
     # Registration & update
@@ -174,6 +189,84 @@ class HelixVisualizer:
                 agent.phase = "synthesis"
         if status:
             agent.status = status
+
+    # ------------------------------------------------------------------
+    # Event bus integration
+    # ------------------------------------------------------------------
+
+    def attach_event_bus(self, bus: EventBus) -> None:
+        """Subscribe to agent lifecycle events for automatic display updates.
+
+        Args:
+            bus: The event bus to subscribe to.
+        """
+        self._event_bus = bus
+        bus.subscribe("agent.*", self._on_agent_event)
+        bus.subscribe("spawn.*", self._on_spawn_event)
+
+    def detach_event_bus(self) -> None:
+        """Remove event subscriptions and detach the bus."""
+        if self._event_bus is not None:
+            self._event_bus.unsubscribe("agent.*", self._on_agent_event)
+            self._event_bus.unsubscribe("spawn.*", self._on_spawn_event)
+            self._event_bus = None
+
+    def _on_agent_event(self, event: FelixEvent) -> None:
+        """Handle agent lifecycle events."""
+        agent_id = event.data.get("agent_id", "")
+        if not agent_id:
+            parts = event.source.split(":")
+            agent_id = parts[1] if len(parts) > 1 else event.source
+
+        handler = self._AGENT_EVENT_HANDLERS.get(event.event_type)
+        if handler is not None:
+            handler(self, agent_id, event)
+
+    def _handle_agent_spawned(self, agent_id: str, event: FelixEvent) -> None:
+        if agent_id not in self._agents:
+            agent_type = event.data.get("agent_type", "")
+            label = agent_type[:2].upper() or agent_id[:2].upper()
+            color = _AGENT_TYPE_COLORS.get(agent_type, "cyan")
+            self.register_agent(agent_id, label=label, color=color)
+
+    def _handle_agent_position(self, agent_id: str, event: FelixEvent) -> None:
+        if agent_id in self._agents:
+            self.update(
+                agent_id,
+                progress=event.data.get("progress", 0.0),
+                confidence=event.data.get("confidence", 0.0),
+                phase=event.data.get("phase", ""),
+            )
+
+    def _handle_agent_completed(self, agent_id: str, event: FelixEvent) -> None:
+        if agent_id in self._agents:
+            self._agents[agent_id].status = "DONE"
+
+    def _handle_agent_failed(self, agent_id: str, event: FelixEvent) -> None:
+        if agent_id in self._agents:
+            self._agents[agent_id].status = "FAILED"
+
+    _AGENT_EVENT_HANDLERS: Dict[str, Any] = {
+        EventType.AGENT_SPAWNED.value: _handle_agent_spawned,
+        EventType.AGENT_POSITION_UPDATED.value: _handle_agent_position,
+        EventType.AGENT_COMPLETED.value: _handle_agent_completed,
+        EventType.AGENT_FAILED.value: _handle_agent_failed,
+    }
+
+    def _on_spawn_event(self, event: FelixEvent) -> None:
+        """Handle dynamic spawning events (new agents picked up via AGENT_SPAWNED)."""
+
+    # ------------------------------------------------------------------
+    # Confidence monitor
+    # ------------------------------------------------------------------
+
+    def set_monitor(self, monitor: ConfidenceMonitor) -> None:
+        """Attach a confidence monitor for trend display in the footer.
+
+        Args:
+            monitor: The confidence monitor to read status from.
+        """
+        self._monitor = monitor
 
     # ------------------------------------------------------------------
     # Rendering — public
@@ -439,7 +532,24 @@ class HelixVisualizer:
             f"  Team Confidence: {colorize(conf_colour, bar)} "
             f"{colorize(BOLD + conf_colour, f'{avg_conf:.1%}')}"
         )
-        return f"{separator}\n{conf_line}"
+
+        monitor_line = ""
+        if self._monitor is not None:
+            status = self._monitor.get_status()
+            trend_icons = {"rising": "\u2191", "falling": "\u2193", "stable": "\u2192"}
+            trend_str = f"{trend_icons.get(status.trend, '?')} {status.trend}"
+            rec = status.recommendation.value.upper()
+            rec_colors = {
+                "spawn": "\033[91m",
+                "hold": PHASE_COLORS["synthesis"],
+                "prune": PHASE_COLORS["analysis"],
+            }
+            rec_color = rec_colors.get(rec.lower(), RESET)
+            monitor_line = (
+                f"\n  Trend: {trend_str}  |  Recommendation: {colorize(BOLD + rec_color, rec)}"
+            )
+
+        return f"{separator}\n{conf_line}{monitor_line}"
 
     # ------------------------------------------------------------------
     # Merge
@@ -453,3 +563,37 @@ class HelixVisualizer:
             side = sidebar[row_idx] if row_idx < len(sidebar) else ""
             lines.append(f"  {canvas_line} \u2502{side}")
         return lines
+
+
+# ---------------------------------------------------------------------------
+# Streaming integration
+# ---------------------------------------------------------------------------
+
+
+class VisualizerStreamHandler(StreamHandler):
+    """A :class:`~felix_agent_sdk.streaming.StreamHandler` that updates the
+    visualizer sidebar as tokens arrive.
+
+    Args:
+        visualizer: The visualizer instance to update.
+        agent_id: The agent whose status line should reflect stream progress.
+    """
+
+    def __init__(self, visualizer: HelixVisualizer, agent_id: str) -> None:
+        self._viz = visualizer
+        self._agent_id = agent_id
+
+    def on_token(self, event: StreamEvent) -> None:
+        """Update agent status with token count."""
+        if self._agent_id in self._viz._agents:
+            self._viz._agents[self._agent_id].status = f"streaming... {event.token_index} tokens"
+
+    def on_result(self, event: StreamEvent) -> None:
+        """Mark agent as complete."""
+        if self._agent_id in self._viz._agents:
+            self._viz._agents[self._agent_id].status = "complete"
+
+    def on_error(self, event: StreamEvent) -> None:
+        """Mark agent as errored."""
+        if self._agent_id in self._viz._agents:
+            self._viz._agents[self._agent_id].status = "ERROR"

--- a/src/felix_agent_sdk/visualization/terminal.py
+++ b/src/felix_agent_sdk/visualization/terminal.py
@@ -1,0 +1,101 @@
+"""ANSI terminal rendering primitives for the helix visualizer.
+
+Pure-stdlib helpers for colour output, cursor control, and simple widgets.
+No external dependencies.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Dict
+
+# ---------------------------------------------------------------------------
+# ANSI colour constants
+# ---------------------------------------------------------------------------
+
+CYAN: str = "\033[96m"
+YELLOW: str = "\033[93m"
+GREEN: str = "\033[92m"
+RED: str = "\033[91m"
+MAGENTA: str = "\033[95m"
+DIM: str = "\033[2m"
+BOLD: str = "\033[1m"
+RESET: str = "\033[0m"
+
+# Phase-to-colour mapping
+PHASE_COLORS: Dict[str, str] = {
+    "exploration": CYAN,
+    "analysis": YELLOW,
+    "synthesis": GREEN,
+}
+
+
+# ---------------------------------------------------------------------------
+# Capability detection
+# ---------------------------------------------------------------------------
+
+
+def supports_color() -> bool:
+    """Return True if the terminal is likely to support ANSI colour codes.
+
+    Checks, in order:
+    - ``NO_COLOR`` env var (https://no-color.org/) — disables colour.
+    - ``FORCE_COLOR`` env var — forces colour on.
+    - ``sys.stdout.isatty()`` — colour only when attached to a real terminal.
+    """
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    return hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+
+def colorize(code: str, text: str) -> str:
+    """Wrap *text* in ANSI *code* if colour is supported.
+
+    Args:
+        code: One or more ANSI escape sequences (e.g. ``BOLD + CYAN``).
+        text: The string to colour.
+
+    Returns:
+        The coloured string, or the plain *text* when colour is disabled.
+    """
+    if supports_color():
+        return f"{code}{text}{RESET}"
+    return text
+
+
+def clear_screen() -> str:
+    """Return the ANSI escape sequence to clear the terminal and home the cursor."""
+    return "\033[2J\033[H"
+
+
+def hide_cursor() -> str:
+    """Return the ANSI escape sequence to hide the text cursor."""
+    return "\033[?25l"
+
+
+def show_cursor() -> str:
+    """Return the ANSI escape sequence to show the text cursor."""
+    return "\033[?25h"
+
+
+def progress_bar(value: float, width: int = 20) -> str:
+    """Render a simple progress bar using block characters.
+
+    Args:
+        value: Progress fraction in ``[0.0, 1.0]``.
+        width: Total character width of the bar.
+
+    Returns:
+        A string like ``"████████░░░░░░░░░░░░"``.
+    """
+    value = max(0.0, min(1.0, value))
+    filled = int(value * width)
+    return "\u2588" * filled + "\u2591" * (width - filled)

--- a/src/felix_agent_sdk/visualization/terminal.py
+++ b/src/felix_agent_sdk/visualization/terminal.py
@@ -30,6 +30,16 @@ PHASE_COLORS: Dict[str, str] = {
     "synthesis": GREEN,
 }
 
+# Friendly name → ANSI code mapping (used by HelixVisualizer.register_agent)
+COLOR_MAP: Dict[str, str] = {
+    "cyan": CYAN,
+    "yellow": YELLOW,
+    "green": GREEN,
+    "red": RED,
+    "magenta": MAGENTA,
+    "white": "\033[97m",
+}
+
 
 # ---------------------------------------------------------------------------
 # Capability detection

--- a/tests/unit/test_helix_visualizer.py
+++ b/tests/unit/test_helix_visualizer.py
@@ -1,0 +1,206 @@
+"""Tests for the helix visualizer module."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from felix_agent_sdk.core.helix import HelixConfig
+from felix_agent_sdk.visualization import AgentDisplayState, HelixVisualizer
+
+
+@pytest.fixture
+def helix():
+    return HelixConfig.default().to_geometry()
+
+
+@pytest.fixture
+def viz(helix):
+    return HelixVisualizer(helix)
+
+
+# ------------------------------------------------------------------
+# Registration
+# ------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register_agent(self, viz):
+        viz.register_agent("rm", label="RM", color="green")
+        assert "rm" in viz._agents
+        assert viz._agents["rm"].label == "RM"
+
+    def test_register_multiple(self, viz):
+        viz.register_agent("a1", "A1")
+        viz.register_agent("a2", "A2")
+        assert len(viz._agents) == 2
+
+    def test_register_default_color(self, viz):
+        viz.register_agent("x", "XX")
+        # Default colour is cyan
+        assert viz._agents["x"].color == "\033[96m"
+
+
+# ------------------------------------------------------------------
+# Update
+# ------------------------------------------------------------------
+
+
+class TestUpdate:
+    def test_update_agent(self, viz):
+        viz.register_agent("rm", "RM")
+        viz.update("rm", progress=0.5, confidence=0.8, phase="analysis")
+        assert viz._agents["rm"].progress == 0.5
+        assert viz._agents["rm"].confidence == 0.8
+        assert viz._agents["rm"].phase == "analysis"
+
+    def test_update_unknown_raises(self, viz):
+        with pytest.raises(KeyError):
+            viz.update("nonexistent", progress=0.5, confidence=0.5)
+
+    def test_update_auto_phase_exploration(self, viz):
+        viz.register_agent("rm", "RM")
+        viz.update("rm", progress=0.1, confidence=0.5)
+        assert viz._agents["rm"].phase == "exploration"
+
+    def test_update_auto_phase_analysis(self, viz):
+        viz.register_agent("rm", "RM")
+        viz.update("rm", progress=0.5, confidence=0.5)
+        assert viz._agents["rm"].phase == "analysis"
+
+    def test_update_auto_phase_synthesis(self, viz):
+        viz.register_agent("rm", "RM")
+        viz.update("rm", progress=0.9, confidence=0.5)
+        assert viz._agents["rm"].phase == "synthesis"
+
+    def test_update_status(self, viz):
+        viz.register_agent("rm", "RM")
+        viz.update("rm", progress=0.3, confidence=0.7, status="Searching...")
+        assert viz._agents["rm"].status == "Searching..."
+
+
+# ------------------------------------------------------------------
+# Render
+# ------------------------------------------------------------------
+
+
+class TestRender:
+    def test_render_to_string_returns_str(self, viz):
+        viz.register_agent("rm", "RM", "green")
+        viz.update("rm", 0.3, 0.7, "exploration")
+        output = viz.render_to_string(tick=1, day=1)
+        assert isinstance(output, str)
+        assert len(output) > 0
+
+    def test_render_contains_agent_labels(self, viz):
+        viz.register_agent("rm", "RM", "green")
+        viz.update("rm", 0.3, 0.7)
+        output = viz.render_to_string()
+        assert "RM" in output
+
+    def test_render_contains_phase_names(self, viz):
+        viz.register_agent("rm", "RM")
+        viz.update("rm", 0.5, 0.5)
+        output = viz.render_to_string()
+        assert (
+            "EXPLORATION" in output
+            or "ANALYSIS" in output
+            or "SYNTHESIS" in output
+        )
+
+    def test_render_header_info(self, viz):
+        viz.register_agent("rm", "RM")
+        viz.update("rm", 0.5, 0.5)
+        output = viz.render_to_string(tick=47, day=12, extra_info={"score": 0.763})
+        assert "47" in output
+        assert "12" in output
+
+    def test_render_extra_info(self, viz):
+        viz.register_agent("rm", "RM")
+        viz.update("rm", 0.5, 0.5)
+        output = viz.render_to_string(extra_info={"score": 0.763})
+        assert "score" in output
+
+    def test_render_team_confidence(self, viz):
+        viz.register_agent("a1", "A1")
+        viz.register_agent("a2", "A2")
+        viz.update("a1", 0.3, 0.8)
+        viz.update("a2", 0.5, 0.6)
+        output = viz.render_to_string()
+        assert "Confidence" in output or "confidence" in output.lower()
+
+    def test_render_empty_agents(self, viz):
+        """Render with no agents should not raise."""
+        output = viz.render_to_string()
+        assert isinstance(output, str)
+
+
+# ------------------------------------------------------------------
+# NO_COLOR
+# ------------------------------------------------------------------
+
+
+class TestNoColor:
+    def test_no_color_env(self, helix, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        from felix_agent_sdk.visualization import terminal
+
+        assert not terminal.supports_color()
+
+    def test_force_color_env(self, helix, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        from felix_agent_sdk.visualization import terminal
+
+        assert terminal.supports_color()
+
+
+# ------------------------------------------------------------------
+# Live context manager
+# ------------------------------------------------------------------
+
+
+class TestLiveContext:
+    def test_live_context_manager(self, viz):
+        with viz.live() as v:
+            assert v is viz
+
+
+# ------------------------------------------------------------------
+# Dimensions
+# ------------------------------------------------------------------
+
+
+class TestDimensions:
+    def test_default_dimensions(self, helix):
+        viz = HelixVisualizer(helix)
+        assert viz._width == 50
+        assert viz._height == 28
+        assert viz._sidebar_width == 40
+
+    def test_custom_dimensions(self, helix):
+        viz = HelixVisualizer(helix, width=60, height=20, sidebar_width=30)
+        assert viz._width == 60
+        assert viz._height == 20
+        assert viz._sidebar_width == 30
+
+    def test_custom_title(self, helix):
+        viz = HelixVisualizer(helix, title="My Helix")
+        assert viz._title == "My Helix"
+
+
+# ------------------------------------------------------------------
+# AgentDisplayState dataclass
+# ------------------------------------------------------------------
+
+
+class TestAgentDisplayState:
+    def test_defaults(self):
+        state = AgentDisplayState(
+            agent_id="test", label="TT", color="\033[96m"
+        )
+        assert state.progress == 0.0
+        assert state.confidence == 0.0
+        assert state.phase == "exploration"
+        assert state.status == ""

--- a/tests/unit/test_helix_visualizer.py
+++ b/tests/unit/test_helix_visualizer.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from felix_agent_sdk.core.helix import HelixConfig
@@ -103,11 +101,7 @@ class TestRender:
         viz.register_agent("rm", "RM")
         viz.update("rm", 0.5, 0.5)
         output = viz.render_to_string()
-        assert (
-            "EXPLORATION" in output
-            or "ANALYSIS" in output
-            or "SYNTHESIS" in output
-        )
+        assert "EXPLORATION" in output or "ANALYSIS" in output or "SYNTHESIS" in output
 
     def test_render_header_info(self, viz):
         viz.register_agent("rm", "RM")
@@ -197,9 +191,7 @@ class TestDimensions:
 
 class TestAgentDisplayState:
     def test_defaults(self):
-        state = AgentDisplayState(
-            agent_id="test", label="TT", color="\033[96m"
-        )
+        state = AgentDisplayState(agent_id="test", label="TT", color="\033[96m")
         assert state.progress == 0.0
         assert state.confidence == 0.0
         assert state.phase == "exploration"

--- a/tests/unit/test_helix_visualizer.py
+++ b/tests/unit/test_helix_visualizer.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import pytest
 
 from felix_agent_sdk.core.helix import HelixConfig
-from felix_agent_sdk.visualization import AgentDisplayState, HelixVisualizer
+from felix_agent_sdk.events import EventBus, EventType, FelixEvent
+from felix_agent_sdk.spawning import ConfidenceMonitor
+from felix_agent_sdk.streaming.types import StreamEvent, StreamEventType
+from felix_agent_sdk.visualization import (
+    AgentDisplayState,
+    HelixVisualizer,
+    VisualizerStreamHandler,
+)
 
 
 @pytest.fixture
@@ -196,3 +203,117 @@ class TestAgentDisplayState:
         assert state.confidence == 0.0
         assert state.phase == "exploration"
         assert state.status == ""
+
+
+# ------------------------------------------------------------------
+# Event bus integration
+# ------------------------------------------------------------------
+
+
+class TestEventBusIntegration:
+    def test_attach_auto_registers_on_spawn(self, viz):
+        bus = EventBus()
+        viz.attach_event_bus(bus)
+        bus.emit(
+            FelixEvent(
+                EventType.AGENT_SPAWNED,
+                "agent:test-001",
+                {"agent_id": "test-001", "agent_type": "research"},
+            )
+        )
+        assert "test-001" in viz._agents
+        assert viz._agents["test-001"].label == "RE"
+
+    def test_event_position_update(self, viz):
+        viz.register_agent("a1", "A1")
+        bus = EventBus()
+        viz.attach_event_bus(bus)
+        bus.emit(
+            FelixEvent(
+                EventType.AGENT_POSITION_UPDATED,
+                "agent:a1",
+                {"agent_id": "a1", "progress": 0.5, "confidence": 0.8},
+            )
+        )
+        assert viz._agents["a1"].progress == pytest.approx(0.5)
+        assert viz._agents["a1"].confidence == pytest.approx(0.8)
+
+    def test_event_agent_completed(self, viz):
+        viz.register_agent("a1", "A1")
+        bus = EventBus()
+        viz.attach_event_bus(bus)
+        bus.emit(
+            FelixEvent(
+                EventType.AGENT_COMPLETED,
+                "agent:a1",
+                {"agent_id": "a1"},
+            )
+        )
+        assert viz._agents["a1"].status == "DONE"
+
+
+# ------------------------------------------------------------------
+# Streaming handler
+# ------------------------------------------------------------------
+
+
+class TestVisualizerStreamHandler:
+    def test_on_token_updates_status(self, viz):
+        viz.register_agent("a1", "A1")
+        handler = VisualizerStreamHandler(viz, "a1")
+        event = StreamEvent(
+            agent_id="a1",
+            event_type=StreamEventType.TOKEN,
+            content="hello",
+            token_index=5,
+        )
+        handler.on_token(event)
+        assert "5 tokens" in viz._agents["a1"].status
+
+    def test_on_result_marks_complete(self, viz):
+        viz.register_agent("a1", "A1")
+        handler = VisualizerStreamHandler(viz, "a1")
+        event = StreamEvent(
+            agent_id="a1",
+            event_type=StreamEventType.RESULT,
+            content="done",
+            is_final=True,
+        )
+        handler.on_result(event)
+        assert viz._agents["a1"].status == "complete"
+
+    def test_on_error_marks_error(self, viz):
+        viz.register_agent("a1", "A1")
+        handler = VisualizerStreamHandler(viz, "a1")
+        event = StreamEvent(
+            agent_id="a1",
+            event_type=StreamEventType.ERROR,
+            content="fail",
+        )
+        handler.on_error(event)
+        assert viz._agents["a1"].status == "ERROR"
+
+
+# ------------------------------------------------------------------
+# Confidence monitor integration
+# ------------------------------------------------------------------
+
+
+class TestConfidenceMonitorIntegration:
+    def test_footer_with_monitor(self, viz):
+        viz.register_agent("a1", "A1")
+        viz.update("a1", 0.5, 0.7)
+        monitor = ConfidenceMonitor(threshold=0.8)
+        monitor.record_round({"a1": 0.7})
+        viz.set_monitor(monitor)
+        output = viz.render_to_string()
+        assert "Trend" in output
+        assert "Recommendation" in output
+
+    def test_footer_without_monitor(self, viz):
+        viz.register_agent("a1", "A1")
+        viz.update("a1", 0.5, 0.7)
+        output = viz.render_to_string()
+        assert "Confidence" in output
+        # Should not crash without monitor
+        assert "Trend" not in output


### PR DESCRIPTION
## Summary
- Adds `src/felix_agent_sdk/visualization/` module with `HelixVisualizer` for real-time ASCII rendering of agents progressing down the helix
- Extracts and generalizes the 2D projection, ANSI rendering, and canvas patterns from `examples/05_deep_research_live/` into a reusable SDK component
- State-based API: `register_agent()` → `update()` → `render()` with `live()` context manager for terminal cleanup

## What it does
Renders a terminal-based helix showing agent positions, phase boundaries (exploration/analysis/synthesis), animated backbone, per-agent sidebar with confidence bars, and team confidence footer. Works on Windows (pure ANSI, no curses). Respects `NO_COLOR`/`FORCE_COLOR` env vars.

## Files
| File | Lines | Purpose |
|------|-------|---------|
| `visualization/__init__.py` | 18 | Exports `HelixVisualizer`, `AgentDisplayState` |
| `visualization/terminal.py` | 101 | ANSI primitives: colors, cursor, progress bars |
| `visualization/helix_visualizer.py` | 485 | Core visualizer: canvas, projection, sidebar, animation |
| `tests/unit/test_helix_visualizer.py` | 206 | 23 tests covering registration, rendering, NO_COLOR, dimensions |
| `__init__.py` | +3 | Added `HelixVisualizer` to top-level exports |

## Usage
```python
from felix_agent_sdk import HelixVisualizer
from felix_agent_sdk.core.helix import HelixConfig

viz = HelixVisualizer(HelixConfig.default().to_geometry())
viz.register_agent("resource_mgr", label="RM", color="green")
viz.update("resource_mgr", progress=0.3, confidence=0.82)
viz.render(tick=47, day=12)
```

## Test plan
- [x] `pytest tests/unit/test_helix_visualizer.py -v` — 23 tests pass
- [x] `pytest tests/ -v` — 686 total pass, no regressions
- [x] `ruff check src/felix_agent_sdk/visualization/` — clean
- [ ] Manual smoke test with multiple agents rendering in a loop
- [x] @CalebisGross review

🤖 Generated with [Claude Code](https://claude.com/claude-code)