### PR TITLE
feat(logging): add structured logging and EventLogBridge

### DIFF
--- a/src/felix_agent_sdk/__init__.py
+++ b/src/felix_agent_sdk/__init__.py
@@ -34,6 +34,7 @@ from felix_agent_sdk.communication import CentralPost, Message, MessageType, Spo
 from felix_agent_sdk.events import EventBus, EventType, FelixEvent
 from felix_agent_sdk.memory import ContextCompressor, KnowledgeStore, TaskMemory
 from felix_agent_sdk.tokens import TokenBudget
+from felix_agent_sdk.utils import configure_logging
 from felix_agent_sdk.workflows import FelixWorkflow, WorkflowConfig, run_felix_workflow
 
 __all__ = [
@@ -71,6 +72,8 @@ __all__ = [
     "EventBus",
     "EventType",
     "FelixEvent",
+    # Logging
+    "configure_logging",
     # Tokens
     "TokenBudget",
 ]

--- a/src/felix_agent_sdk/events/bus.py
+++ b/src/felix_agent_sdk/events/bus.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 EventCallback = Callable[[FelixEvent], None]
 
 
+# Enough to capture a full workflow run (~20 rounds × ~10 agents × ~3 events)
+# without unbounded growth in long-running processes.
+_DEFAULT_MAX_HISTORY = 10_000
+
+
 class EventBus:
     """Synchronous event bus with prefix-pattern subscriptions.
 
@@ -48,16 +53,24 @@ class EventBus:
         self._lock = threading.Lock()
         self._history: List[FelixEvent] = []
         self._record_history = False
+        self._max_history_size = _DEFAULT_MAX_HISTORY
 
     # ------------------------------------------------------------------
     # Configuration
     # ------------------------------------------------------------------
 
-    def enable_history(self, enabled: bool = True) -> None:
+    def enable_history(self, enabled: bool = True, max_size: int = _DEFAULT_MAX_HISTORY) -> None:
         """Toggle event recording. When enabled, all emitted events are
-        stored in :attr:`history` for later inspection."""
+        stored in :attr:`history` for later inspection.
+
+        Args:
+            enabled: Whether to record events.
+            max_size: Maximum number of events to retain. Oldest events
+                are discarded when the limit is reached.
+        """
         with self._lock:
             self._record_history = enabled
+            self._max_history_size = max_size
             if not enabled:
                 self._history.clear()
 
@@ -120,6 +133,8 @@ class EventBus:
         with self._lock:
             if self._record_history:
                 self._history.append(event)
+                if len(self._history) > self._max_history_size:
+                    self._history = self._history[-self._max_history_size:]
 
             targets: List[EventCallback] = []
 

--- a/src/felix_agent_sdk/events/types.py
+++ b/src/felix_agent_sdk/events/types.py
@@ -58,7 +58,9 @@ class FelixEvent:
     """An immutable record of something that happened in the SDK.
 
     Attributes:
-        event_type: The event category (from :class:`EventType` or a custom string).
+        event_type: The event category as a plain string.  Accepts
+            :class:`EventType` enum members — they are normalised to
+            their ``.value`` on construction.
         source: Identifies the emitter, e.g. ``"workflow"`` or ``"agent:research-001"``.
         data: Arbitrary payload. Contents vary by event type.
         timestamp: Monotonic timestamp (seconds) when the event was created.
@@ -68,3 +70,11 @@ class FelixEvent:
     source: str
     data: Dict[str, Any] = field(default_factory=dict)
     timestamp: float = field(default_factory=time.monotonic)
+
+    def __post_init__(self) -> None:
+        # Normalise EventType enum members to plain strings so that
+        # str(), logging %-formatting, and == comparisons all behave
+        # consistently across Python versions.
+        et = self.event_type
+        if hasattr(et, "value"):
+            object.__setattr__(self, "event_type", et.value)

--- a/src/felix_agent_sdk/utils/__init__.py
+++ b/src/felix_agent_sdk/utils/__init__.py
@@ -1,8 +1,18 @@
 """Felix shared utilities.
 
-Logging, configuration loading, and common type definitions.
-
-Status: Stub — populated as needed during implementation.
+Logging configuration, event-log bridging, and common helpers.
 """
 
-__all__: list[str] = []
+from felix_agent_sdk.utils.logging import (
+    EventLogBridge,
+    FelixLogConfig,
+    JSONFormatter,
+    configure_logging,
+)
+
+__all__ = [
+    "configure_logging",
+    "FelixLogConfig",
+    "JSONFormatter",
+    "EventLogBridge",
+]

--- a/src/felix_agent_sdk/utils/logging.py
+++ b/src/felix_agent_sdk/utils/logging.py
@@ -1,0 +1,216 @@
+"""Structured logging configuration for the Felix SDK.
+
+Provides a one-call ``configure_logging()`` helper that sets up sensible
+defaults for all ``felix_agent_sdk.*`` loggers, plus an ``EventLogBridge``
+that subscribes to an :class:`EventBus` and logs every event automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Literal, Optional
+
+from felix_agent_sdk.events.bus import EventBus
+from felix_agent_sdk.events.types import FelixEvent
+
+_ROOT_LOGGER_NAME = "felix_agent_sdk"
+
+# Default log level mapping for events (event_type prefix → level name)
+_DEFAULT_EVENT_LEVELS: Dict[str, str] = {
+    "workflow.started": "INFO",
+    "workflow.completed": "INFO",
+    "workflow.converged": "INFO",
+    "workflow.round": "DEBUG",
+    "workflow.synthesis": "DEBUG",
+    "task.": "DEBUG",
+    "agent.": "DEBUG",
+    "message.": "DEBUG",
+    "stream.": "DEBUG",
+    "spawn.": "INFO",
+}
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FelixLogConfig:
+    """Configuration for :func:`configure_logging`.
+
+    Attributes:
+        level: Root log level for all ``felix_agent_sdk.*`` loggers.
+        format: ``"text"`` for human-readable, ``"json"`` for structured output.
+        subsystem_levels: Override levels for specific loggers, e.g.
+            ``{"felix_agent_sdk.providers": "DEBUG"}``.
+        include_timestamps: Prefix lines with ISO-8601 timestamps (text mode).
+        output_handler: Pre-built handler to use. When ``None`` a
+            :class:`logging.StreamHandler` writing to stderr is created.
+    """
+
+    level: str = "INFO"
+    format: Literal["text", "json"] = "text"
+    subsystem_levels: Dict[str, str] = field(default_factory=dict)
+    include_timestamps: bool = True
+    output_handler: Optional[logging.Handler] = field(default=None, repr=False)
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+class JSONFormatter(logging.Formatter):
+    """Emit each log record as a single JSON object per line.
+
+    Fields: ``timestamp``, ``level``, ``logger``, ``message``, and any
+    ``extra`` keys set on the record.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        obj: Dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        # Capture extra fields attached by EventLogBridge or user code
+        for key in ("event_type", "event_source", "event_data"):
+            val = getattr(record, key, None)
+            if val is not None:
+                obj[key] = val
+        if record.exc_info and record.exc_info[1] is not None:
+            obj["exception"] = self.formatException(record.exc_info)
+        return json.dumps(obj, default=str)
+
+
+def _build_text_formatter(include_timestamps: bool) -> logging.Formatter:
+    parts = []
+    if include_timestamps:
+        parts.append("%(asctime)s")
+    parts.extend(["%(levelname)-8s", "%(name)s", "%(message)s"])
+    return logging.Formatter(" ".join(parts))
+
+
+# ---------------------------------------------------------------------------
+# configure_logging
+# ---------------------------------------------------------------------------
+
+
+def configure_logging(config: Optional[FelixLogConfig] = None) -> None:
+    """Set up logging for all ``felix_agent_sdk.*`` loggers.
+
+    Idempotent — safe to call multiple times. Subsequent calls replace
+    the handler and formatter but do not duplicate handlers.
+
+    Args:
+        config: Logging configuration. Uses sensible defaults when ``None``.
+    """
+    cfg = config or FelixLogConfig()
+
+    root = logging.getLogger(_ROOT_LOGGER_NAME)
+    root.setLevel(getattr(logging, cfg.level.upper(), logging.INFO))
+
+    # Remove any handlers previously attached by this function
+    for h in list(root.handlers):
+        if getattr(h, "_felix_managed", False):
+            root.removeHandler(h)
+
+    handler = cfg.output_handler or logging.StreamHandler()
+    handler._felix_managed = True  # type: ignore[attr-defined]
+
+    if cfg.format == "json":
+        handler.setFormatter(JSONFormatter())
+    else:
+        handler.setFormatter(_build_text_formatter(cfg.include_timestamps))
+
+    root.addHandler(handler)
+
+    # Per-subsystem overrides
+    for logger_name, level_str in cfg.subsystem_levels.items():
+        sub = logging.getLogger(logger_name)
+        sub.setLevel(getattr(logging, level_str.upper(), logging.INFO))
+
+
+# ---------------------------------------------------------------------------
+# EventLogBridge
+# ---------------------------------------------------------------------------
+
+
+class EventLogBridge:
+    """Subscribe to an :class:`EventBus` and log every event.
+
+    Each event is logged to the ``felix_agent_sdk.events`` logger at a
+    level determined by the event type (see ``_DEFAULT_EVENT_LEVELS``).
+    Custom level mappings can be provided via *level_map*.
+
+    Examples::
+
+        bus = EventBus()
+        configure_logging()
+        bridge = EventLogBridge(bus)
+        # Now every event emitted on *bus* appears in the log.
+
+        # Cleanup
+        bridge.detach()
+    """
+
+    def __init__(
+        self,
+        bus: EventBus,
+        level_map: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self._bus = bus
+        self._level_map = level_map or dict(_DEFAULT_EVENT_LEVELS)
+        self._logger = logging.getLogger(f"{_ROOT_LOGGER_NAME}.events")
+        bus.subscribe_all(self._on_event)
+
+    # ------------------------------------------------------------------
+
+    def _resolve_level(self, event_type: str) -> int:
+        """Return the numeric log level for *event_type*."""
+        # Exact match first
+        level_str = self._level_map.get(event_type)
+        if level_str:
+            return getattr(logging, level_str.upper(), logging.DEBUG)
+        # Prefix match
+        for prefix, lvl in self._level_map.items():
+            if event_type.startswith(prefix):
+                return getattr(logging, lvl.upper(), logging.DEBUG)
+        return logging.DEBUG
+
+    def _on_event(self, event: FelixEvent) -> None:
+        level = self._resolve_level(event.event_type)
+        extra = {
+            "event_type": event.event_type,
+            "event_source": event.source,
+            "event_data": event.data,
+        }
+        self._logger.log(
+            level,
+            "[%s] %s %s",
+            event.event_type,
+            event.source,
+            _summarise_data(event.data),
+            extra=extra,
+        )
+
+    # ------------------------------------------------------------------
+
+    def detach(self) -> None:
+        """Unsubscribe from the event bus."""
+        self._bus.unsubscribe_all(self._on_event)
+
+
+def _summarise_data(data: Dict[str, Any], max_len: int = 120) -> str:
+    """One-line summary of event data for text logs."""
+    if not data:
+        return ""
+    parts = [f"{k}={v}" for k, v in data.items()]
+    text = " ".join(parts)
+    if len(text) > max_len:
+        return text[: max_len - 3] + "..."
+    return text

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,246 @@
+"""Tests for structured logging configuration and EventLogBridge."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from felix_agent_sdk.events import EventBus, EventType, FelixEvent
+from felix_agent_sdk.utils.logging import (
+    EventLogBridge,
+    FelixLogConfig,
+    JSONFormatter,
+    configure_logging,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _capture_handler() -> logging.Handler:
+    """Return a handler that stores formatted records in handler.records."""
+    handler = logging.StreamHandler()
+    handler.records: list[str] = []  # type: ignore[attr-defined]
+    original_emit = handler.emit
+
+    def capturing_emit(record: logging.LogRecord) -> None:
+        handler.records.append(handler.format(record))  # type: ignore[attr-defined]
+
+    handler.emit = capturing_emit  # type: ignore[method-assign]
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# configure_logging
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureLogging:
+    def setup_method(self):
+        # Clean up any managed handlers from previous tests
+        root = logging.getLogger("felix_agent_sdk")
+        for h in list(root.handlers):
+            if getattr(h, "_felix_managed", False):
+                root.removeHandler(h)
+
+    def test_default_config(self):
+        configure_logging()
+        root = logging.getLogger("felix_agent_sdk")
+        assert root.level == logging.INFO
+        managed = [h for h in root.handlers if getattr(h, "_felix_managed", False)]
+        assert len(managed) == 1
+
+    def test_custom_level(self):
+        configure_logging(FelixLogConfig(level="DEBUG"))
+        root = logging.getLogger("felix_agent_sdk")
+        assert root.level == logging.DEBUG
+
+    def test_idempotent(self):
+        configure_logging()
+        configure_logging()
+        root = logging.getLogger("felix_agent_sdk")
+        managed = [h for h in root.handlers if getattr(h, "_felix_managed", False)]
+        assert len(managed) == 1  # not 2
+
+    def test_subsystem_levels(self):
+        configure_logging(
+            FelixLogConfig(subsystem_levels={"felix_agent_sdk.providers": "WARNING"})
+        )
+        sub = logging.getLogger("felix_agent_sdk.providers")
+        assert sub.level == logging.WARNING
+
+    def test_custom_handler(self):
+        handler = _capture_handler()
+        configure_logging(FelixLogConfig(output_handler=handler))
+        logger = logging.getLogger("felix_agent_sdk.test_custom")
+        logger.info("hello")
+        assert any("hello" in r for r in handler.records)  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# JSONFormatter
+# ---------------------------------------------------------------------------
+
+
+class TestJSONFormatter:
+    def test_valid_json(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="felix_agent_sdk.test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="test message",
+            args=(),
+            exc_info=None,
+        )
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["level"] == "INFO"
+        assert parsed["logger"] == "felix_agent_sdk.test"
+        assert parsed["message"] == "test message"
+        assert "timestamp" in parsed
+
+    def test_extra_fields(self):
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="msg", args=(), exc_info=None,
+        )
+        record.event_type = "workflow.started"  # type: ignore[attr-defined]
+        record.event_source = "workflow"  # type: ignore[attr-defined]
+        record.event_data = {"task": "test"}  # type: ignore[attr-defined]
+
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["event_type"] == "workflow.started"
+        assert parsed["event_source"] == "workflow"
+        assert parsed["event_data"] == {"task": "test"}
+
+    def test_json_format_via_configure(self):
+        handler = _capture_handler()
+        configure_logging(FelixLogConfig(format="json", output_handler=handler))
+        logger = logging.getLogger("felix_agent_sdk.test_json")
+        logger.info("json test")
+        assert len(handler.records) > 0  # type: ignore[attr-defined]
+        parsed = json.loads(handler.records[0])  # type: ignore[attr-defined]
+        assert parsed["message"] == "json test"
+
+
+# ---------------------------------------------------------------------------
+# Text formatter
+# ---------------------------------------------------------------------------
+
+
+class TestTextFormatter:
+    def test_with_timestamps(self):
+        handler = _capture_handler()
+        configure_logging(
+            FelixLogConfig(format="text", include_timestamps=True, output_handler=handler)
+        )
+        logger = logging.getLogger("felix_agent_sdk.test_text_ts")
+        logger.info("ts test")
+        # Should contain a timestamp-like pattern (year)
+        assert any("202" in r for r in handler.records)  # type: ignore[attr-defined]
+
+    def test_without_timestamps(self):
+        handler = _capture_handler()
+        configure_logging(
+            FelixLogConfig(format="text", include_timestamps=False, output_handler=handler)
+        )
+        logger = logging.getLogger("felix_agent_sdk.test_text_nots")
+        logger.info("no ts")
+        # First token should be the level, not a timestamp
+        assert handler.records[0].startswith("INFO")  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# EventLogBridge
+# ---------------------------------------------------------------------------
+
+
+class TestEventLogBridge:
+    def test_logs_events(self):
+        handler = _capture_handler()
+        configure_logging(FelixLogConfig(level="DEBUG", output_handler=handler))
+
+        bus = EventBus()
+        bridge = EventLogBridge(bus)
+
+        bus.emit(FelixEvent(
+            event_type=EventType.WORKFLOW_STARTED,
+            source="workflow",
+            data={"task": "test"},
+        ))
+
+        assert any("workflow.started" in r for r in handler.records)  # type: ignore[attr-defined]
+
+    def test_json_bridge(self):
+        handler = _capture_handler()
+        configure_logging(FelixLogConfig(level="DEBUG", format="json", output_handler=handler))
+
+        bus = EventBus()
+        bridge = EventLogBridge(bus)
+
+        bus.emit(FelixEvent(
+            event_type=EventType.TASK_COMPLETED,
+            source="agent:research-001",
+            data={"confidence": 0.75},
+        ))
+
+        assert len(handler.records) > 0  # type: ignore[attr-defined]
+        parsed = json.loads(handler.records[0])  # type: ignore[attr-defined]
+        assert parsed["event_type"] == "task.completed"
+        assert parsed["event_source"] == "agent:research-001"
+
+    def test_detach(self):
+        handler = _capture_handler()
+        configure_logging(FelixLogConfig(level="DEBUG", output_handler=handler))
+
+        bus = EventBus()
+        bridge = EventLogBridge(bus)
+        bridge.detach()
+
+        bus.emit(FelixEvent(event_type="test", source="test"))
+        # Should have no event log records after detach
+        event_records = [r for r in handler.records if "test" in r and "[test]" in r]  # type: ignore[attr-defined]
+        assert len(event_records) == 0
+
+    def test_custom_level_map(self):
+        handler = _capture_handler()
+        configure_logging(FelixLogConfig(level="DEBUG", output_handler=handler))
+
+        bus = EventBus()
+        bridge = EventLogBridge(bus, level_map={"custom.event": "WARNING"})
+
+        bus.emit(FelixEvent(event_type="custom.event", source="test"))
+
+        assert any("WARNING" in r for r in handler.records)  # type: ignore[attr-defined]
+
+    def test_default_level_is_debug(self):
+        handler = _capture_handler()
+        configure_logging(FelixLogConfig(level="DEBUG", output_handler=handler))
+
+        bus = EventBus()
+        bridge = EventLogBridge(bus)
+
+        bus.emit(FelixEvent(event_type="unknown.event.type", source="test"))
+
+        assert any("DEBUG" in r for r in handler.records)  # type: ignore[attr-defined]
+
+    def test_workflow_events_log_at_info(self):
+        handler = _capture_handler()
+        configure_logging(FelixLogConfig(level="DEBUG", output_handler=handler))
+
+        bus = EventBus()
+        bridge = EventLogBridge(bus)
+
+        bus.emit(FelixEvent(event_type=EventType.WORKFLOW_STARTED, source="wf"))
+        bus.emit(FelixEvent(event_type=EventType.WORKFLOW_COMPLETED, source="wf"))
+
+        info_records = [r for r in handler.records if "INFO" in r]  # type: ignore[attr-defined]
+        assert len(info_records) >= 2


### PR DESCRIPTION
## Summary

- **`configure_logging()`** — one-call setup for all `felix_agent_sdk.*` loggers. Text or JSON format, per-subsystem level overrides. Idempotent.
- **`FelixLogConfig`** — dataclass: level, format, subsystem_levels, include_timestamps, custom handler
- **`JSONFormatter`** — structured JSON with event_type, event_source, event_data fields
- **`EventLogBridge`** — subscribes to EventBus, auto-logs events at configurable levels (workflow at INFO, task/agent at DEBUG). Detachable.
- **`FelixEvent.__post_init__`** — normalises EventType enum members to plain strings for consistent formatting across Python 3.10-3.13

## Test plan
- [x] 16 new tests (configure, JSON, text, bridge, detach, level mapping)
- [x] 714 total tests passing
- [x] `ruff check src/` clean
- [x] 1 new top-level export: `configure_logging`

Depends on PR #20 (event system). Contributes to Phase 2.