### PR TITLE
feat(streaming): add streaming types, handlers, and accumulator

### DIFF
--- a/src/felix_agent_sdk/__init__.py
+++ b/src/felix_agent_sdk/__init__.py
@@ -33,6 +33,7 @@ from felix_agent_sdk.providers import (
 from felix_agent_sdk.communication import CentralPost, Message, MessageType, Spoke
 from felix_agent_sdk.events import EventBus, EventType, FelixEvent
 from felix_agent_sdk.memory import ContextCompressor, KnowledgeStore, TaskMemory
+from felix_agent_sdk.streaming import StreamEvent, StreamHandler
 from felix_agent_sdk.tokens import TokenBudget
 from felix_agent_sdk.utils import configure_logging
 from felix_agent_sdk.workflows import FelixWorkflow, WorkflowConfig, run_felix_workflow
@@ -72,6 +73,9 @@ __all__ = [
     "EventBus",
     "EventType",
     "FelixEvent",
+    # Streaming
+    "StreamEvent",
+    "StreamHandler",
     # Logging
     "configure_logging",
     # Tokens

--- a/src/felix_agent_sdk/agents/llm_agent.py
+++ b/src/felix_agent_sdk/agents/llm_agent.py
@@ -24,6 +24,8 @@ from felix_agent_sdk.events.mixins import EventEmitterMixin
 from felix_agent_sdk.events.types import EventType
 from felix_agent_sdk.providers.base import BaseProvider
 from felix_agent_sdk.providers.types import ChatMessage, CompletionResult, MessageRole
+from felix_agent_sdk.streaming.accumulator import StreamAccumulator
+from felix_agent_sdk.streaming.handler import StreamHandler
 from felix_agent_sdk.tokens.budget import TokenBudget
 
 logger = logging.getLogger(__name__)
@@ -361,6 +363,88 @@ class LLMAgent(Agent, EventEmitterMixin):
                 "tokens": completion.total_tokens,
                 "processing_time": round(elapsed, 4),
                 "phase": result.position_info.get("phase", ""),
+            },
+            source=f"agent:{self.agent_id}",
+        )
+
+        return result
+
+    def process_task_streaming(
+        self, task: LLMTask, handler: StreamHandler
+    ) -> LLMResult:
+        """Process a task with token-level streaming.
+
+        Same lifecycle as :meth:`process_task` (prompt -> provider ->
+        confidence -> result) but uses ``provider.stream()`` and
+        dispatches each chunk through *handler*.
+
+        Args:
+            task: The task to process.
+            handler: Stream handler to receive token events.
+
+        Returns:
+            :class:`LLMResult` identical to what ``process_task`` would
+            return for the same content.
+        """
+        start = time.monotonic()
+
+        self.emit_event(
+            EventType.TASK_STARTED,
+            {"task_id": task.task_id, "agent_type": self.agent_type, "streaming": True},
+            source=f"agent:{self.agent_id}",
+        )
+
+        temperature = self.get_adaptive_temperature()
+        system_prompt, user_prompt = self.create_position_aware_prompt(task)
+        max_tokens = self.max_tokens
+
+        messages = [
+            ChatMessage(role=MessageRole.SYSTEM, content=system_prompt),
+            ChatMessage(role=MessageRole.USER, content=user_prompt),
+        ]
+
+        accumulator = StreamAccumulator(
+            agent_id=self.agent_id,
+            handler=handler,
+            model=getattr(self.provider, "model", ""),
+        )
+        chunks = self.provider.stream(
+            messages, temperature=temperature, max_tokens=max_tokens
+        )
+        accumulator.feed_all(chunks)
+        completion = accumulator.to_completion_result()
+
+        confidence = self.calculate_confidence(completion.content)
+        self.record_confidence(confidence)
+
+        elapsed = time.monotonic() - start
+        self.total_tokens_used += completion.total_tokens
+        self.total_processing_time += elapsed
+
+        result = LLMResult(
+            agent_id=self.agent_id,
+            task_id=task.task_id,
+            content=completion.content,
+            position_info=self.get_position_info(),
+            completion_result=completion,
+            processing_time=elapsed,
+            confidence=confidence,
+            temperature_used=temperature,
+            token_budget_used=completion.total_tokens,
+        )
+        self.processing_results.append(result)
+
+        self.emit_event(
+            EventType.TASK_COMPLETED,
+            {
+                "task_id": task.task_id,
+                "agent_type": self.agent_type,
+                "confidence": round(confidence, 4),
+                "temperature": round(temperature, 4),
+                "tokens": completion.total_tokens,
+                "processing_time": round(elapsed, 4),
+                "phase": result.position_info.get("phase", ""),
+                "streaming": True,
             },
             source=f"agent:{self.agent_id}",
         )

--- a/src/felix_agent_sdk/streaming/__init__.py
+++ b/src/felix_agent_sdk/streaming/__init__.py
@@ -1,9 +1,22 @@
 """Felix real-time output streaming.
 
-Stream event types and handlers for token-by-token output.
-Planned exports: StreamEvent, StreamHandler.
-
-Status: Stub — implementation in feat/workflows branch.
+Stream event types, handlers, and accumulator for token-by-token output
+observation during agent processing.
 """
 
-__all__: list[str] = []
+from felix_agent_sdk.streaming.accumulator import StreamAccumulator
+from felix_agent_sdk.streaming.handler import (
+    CallbackStreamHandler,
+    EventBusStreamHandler,
+    StreamHandler,
+)
+from felix_agent_sdk.streaming.types import StreamEvent, StreamEventType
+
+__all__ = [
+    "StreamAccumulator",
+    "StreamHandler",
+    "CallbackStreamHandler",
+    "EventBusStreamHandler",
+    "StreamEvent",
+    "StreamEventType",
+]

--- a/src/felix_agent_sdk/streaming/accumulator.py
+++ b/src/felix_agent_sdk/streaming/accumulator.py
@@ -1,0 +1,83 @@
+"""Stream accumulator — bridges provider StreamChunks to SDK StreamEvents."""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+from felix_agent_sdk.providers.types import CompletionResult, StreamChunk
+from felix_agent_sdk.streaming.handler import StreamHandler
+from felix_agent_sdk.streaming.types import StreamEvent, StreamEventType
+
+
+class StreamAccumulator:
+    """Consume :class:`StreamChunk` objects from a provider and produce
+    :class:`StreamEvent` objects dispatched to a :class:`StreamHandler`.
+
+    After iteration completes, :meth:`to_completion_result` returns the
+    equivalent :class:`CompletionResult` so the caller can treat the
+    stream result identically to a non-streaming ``complete()`` call.
+
+    Args:
+        agent_id: Agent producing the stream.
+        handler: Handler to dispatch events to.
+        model: Model identifier for the completion result.
+    """
+
+    def __init__(self, agent_id: str, handler: StreamHandler, model: str = "") -> None:
+        self._agent_id = agent_id
+        self._handler = handler
+        self._model = model
+        self._accumulated = ""
+        self._token_index = 0
+        self._usage: dict[str, int] = {}
+
+    def feed(self, chunk: StreamChunk) -> None:
+        """Process a single :class:`StreamChunk`."""
+        self._accumulated += chunk.text
+        self._token_index += 1
+
+        if chunk.is_final:
+            self._usage = dict(chunk.usage)
+            event = StreamEvent(
+                agent_id=self._agent_id,
+                event_type=StreamEventType.RESULT,
+                content=chunk.text,
+                accumulated=self._accumulated,
+                token_index=self._token_index,
+                is_final=True,
+                usage=self._usage,
+            )
+            self._handler.dispatch(event)
+        else:
+            event = StreamEvent(
+                agent_id=self._agent_id,
+                event_type=StreamEventType.TOKEN,
+                content=chunk.text,
+                accumulated=self._accumulated,
+                token_index=self._token_index,
+                is_final=False,
+            )
+            self._handler.dispatch(event)
+
+    def feed_all(self, chunks: Iterator[StreamChunk]) -> None:
+        """Consume all chunks from an iterator."""
+        for chunk in chunks:
+            self.feed(chunk)
+
+    def to_completion_result(self) -> CompletionResult:
+        """Build a :class:`CompletionResult` from the accumulated stream."""
+        return CompletionResult(
+            content=self._accumulated,
+            model=self._model,
+            usage=self._usage,
+        )
+
+    @property
+    def accumulated_text(self) -> str:
+        """The full text accumulated so far."""
+        return self._accumulated
+
+    @property
+    def token_count(self) -> int:
+        """Number of chunks received."""
+        return self._token_index

--- a/src/felix_agent_sdk/streaming/handler.py
+++ b/src/felix_agent_sdk/streaming/handler.py
@@ -1,0 +1,105 @@
+"""Stream handler base class and built-in implementations."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from felix_agent_sdk.events.bus import EventBus
+from felix_agent_sdk.events.types import EventType, FelixEvent
+from felix_agent_sdk.streaming.types import StreamEvent, StreamEventType
+
+
+class StreamHandler:
+    """Base class for consuming stream events.
+
+    Override the ``on_*`` methods to handle specific event types.
+    Default implementations are no-ops.
+
+    Examples::
+
+        class PrintHandler(StreamHandler):
+            def on_token(self, event: StreamEvent) -> None:
+                print(event.content, end="", flush=True)
+
+            def on_result(self, event: StreamEvent) -> None:
+                print()  # newline after stream completes
+    """
+
+    def on_token(self, event: StreamEvent) -> None:
+        """Called for each token/chunk received."""
+
+    def on_result(self, event: StreamEvent) -> None:
+        """Called when the stream completes with the full result."""
+
+    def on_error(self, event: StreamEvent) -> None:
+        """Called if an error occurs during streaming."""
+
+    def dispatch(self, event: StreamEvent) -> None:
+        """Route *event* to the appropriate ``on_*`` method."""
+        if event.event_type == StreamEventType.TOKEN:
+            self.on_token(event)
+        elif event.event_type == StreamEventType.CHUNK:
+            self.on_token(event)  # chunks are batched tokens
+        elif event.event_type == StreamEventType.RESULT:
+            self.on_result(event)
+        elif event.event_type == StreamEventType.ERROR:
+            self.on_error(event)
+
+
+class CallbackStreamHandler(StreamHandler):
+    """Stream handler backed by simple callables.
+
+    Examples::
+
+        handler = CallbackStreamHandler(
+            on_token=lambda e: print(e.content, end=""),
+            on_result=lambda e: print(f"\\nDone: {len(e.accumulated)} chars"),
+        )
+    """
+
+    def __init__(
+        self,
+        on_token: Optional[Callable[[StreamEvent], None]] = None,
+        on_result: Optional[Callable[[StreamEvent], None]] = None,
+        on_error: Optional[Callable[[StreamEvent], None]] = None,
+    ) -> None:
+        self._on_token = on_token
+        self._on_result = on_result
+        self._on_error = on_error
+
+    def on_token(self, event: StreamEvent) -> None:
+        if self._on_token is not None:
+            self._on_token(event)
+
+    def on_result(self, event: StreamEvent) -> None:
+        if self._on_result is not None:
+            self._on_result(event)
+
+    def on_error(self, event: StreamEvent) -> None:
+        if self._on_error is not None:
+            self._on_error(event)
+
+
+class EventBusStreamHandler(StreamHandler):
+    """Stream handler that re-emits stream events onto an EventBus."""
+
+    def __init__(self, bus: EventBus) -> None:
+        self._bus = bus
+
+    def on_token(self, event: StreamEvent) -> None:
+        self._bus.emit(FelixEvent(
+            event_type=EventType.STREAM_TOKEN,
+            source=f"agent:{event.agent_id}",
+            data={"content": event.content, "token_index": event.token_index},
+        ))
+
+    def on_result(self, event: StreamEvent) -> None:
+        self._bus.emit(FelixEvent(
+            event_type=EventType.STREAM_COMPLETED,
+            source=f"agent:{event.agent_id}",
+            data={
+                "length": len(event.accumulated),
+                "token_count": event.token_index,
+                "usage": event.usage,
+            },
+        ))

--- a/src/felix_agent_sdk/streaming/types.py
+++ b/src/felix_agent_sdk/streaming/types.py
@@ -1,0 +1,42 @@
+"""Streaming event types for real-time agent output observation."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict
+
+
+class StreamEventType(str, Enum):
+    """Types of streaming events."""
+
+    TOKEN = "token"
+    CHUNK = "chunk"
+    RESULT = "result"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class StreamEvent:
+    """A single event from a streaming agent response.
+
+    Attributes:
+        agent_id: The agent producing the stream.
+        event_type: The kind of streaming event.
+        content: Incremental text content.
+        accumulated: Full text accumulated so far.
+        token_index: Number of tokens/chunks received so far.
+        is_final: Whether this is the last event in the stream.
+        usage: Token usage stats (populated on final event).
+        timestamp: Monotonic timestamp.
+    """
+
+    agent_id: str
+    event_type: StreamEventType
+    content: str
+    accumulated: str = ""
+    token_index: int = 0
+    is_final: bool = False
+    usage: Dict[str, int] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time.monotonic)

--- a/tests/unit/test_llm_agent_streaming.py
+++ b/tests/unit/test_llm_agent_streaming.py
@@ -1,0 +1,157 @@
+"""Tests for LLMAgent.process_task_streaming()."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from felix_agent_sdk.agents.llm_agent import LLMAgent, LLMTask
+from felix_agent_sdk.core.helix import HelixConfig, HelixGeometry
+from felix_agent_sdk.events import EventBus, EventType
+from felix_agent_sdk.providers.base import BaseProvider
+from felix_agent_sdk.providers.types import CompletionResult, StreamChunk
+from felix_agent_sdk.streaming import CallbackStreamHandler, StreamHandler
+
+
+def _make_helix() -> HelixGeometry:
+    cfg = HelixConfig.default()
+    return HelixGeometry(cfg.top_radius, cfg.bottom_radius, cfg.height, cfg.turns)
+
+
+def _make_streaming_provider(text: str = "Hello streaming world!") -> BaseProvider:
+    """Mock provider whose stream() yields word-by-word chunks."""
+    provider = MagicMock(spec=BaseProvider)
+
+    words = text.split(" ")
+    chunks = []
+    for i, word in enumerate(words):
+        is_last = i == len(words) - 1
+        suffix = "" if is_last else " "
+        chunks.append(StreamChunk(
+            text=word + suffix,
+            is_final=is_last,
+            usage={"prompt_tokens": 10, "completion_tokens": len(words), "total_tokens": 10 + len(words)} if is_last else {},
+        ))
+
+    provider.stream.return_value = iter(chunks)
+    # Also set up complete() for comparison
+    provider.complete.return_value = CompletionResult(
+        content=text,
+        model="mock",
+        usage={"prompt_tokens": 10, "completion_tokens": len(words), "total_tokens": 10 + len(words)},
+    )
+    provider.count_tokens.return_value = 10
+    return provider
+
+
+class TestProcessTaskStreaming:
+    def test_produces_same_content_as_process_task(self):
+        text = "Research finds renewable energy growing rapidly."
+        helix = _make_helix()
+
+        # Streaming path
+        provider_s = _make_streaming_provider(text)
+        agent_s = LLMAgent("s-001", provider_s, helix, agent_type="research")
+        agent_s.spawn(0.1)
+        agent_s.update_position(0.5)
+        task = LLMTask(task_id="t1", description="Test task")
+        result_s = agent_s.process_task_streaming(task, StreamHandler())
+
+        # Non-streaming path
+        provider_c = _make_streaming_provider(text)
+        agent_c = LLMAgent("c-001", provider_c, helix, agent_type="research")
+        agent_c.spawn(0.1)
+        agent_c.update_position(0.5)
+        result_c = agent_c.process_task(LLMTask(task_id="t1", description="Test task"))
+
+        assert result_s.content == result_c.content
+        assert result_s.content == text
+
+    def test_handler_receives_tokens(self):
+        tokens = []
+        handler = CallbackStreamHandler(on_token=lambda e: tokens.append(e.content))
+
+        provider = _make_streaming_provider("one two three")
+        helix = _make_helix()
+        agent = LLMAgent("a-001", provider, helix, agent_type="research")
+        agent.spawn(0.1)
+        agent.update_position(0.5)
+
+        result = agent.process_task_streaming(
+            LLMTask(task_id="t1", description="Test"), handler
+        )
+
+        assert tokens == ["one ", "two "]  # "three" is final → dispatched as result
+        assert result.content == "one two three"
+
+    def test_handler_receives_final_result(self):
+        results = []
+        handler = CallbackStreamHandler(on_result=lambda e: results.append(e))
+
+        provider = _make_streaming_provider("hello world")
+        helix = _make_helix()
+        agent = LLMAgent("a-001", provider, helix, agent_type="analysis")
+        agent.spawn(0.1)
+        agent.update_position(0.5)
+
+        agent.process_task_streaming(
+            LLMTask(task_id="t1", description="Test"), handler
+        )
+
+        assert len(results) == 1
+        assert results[0].is_final is True
+        assert results[0].accumulated == "hello world"
+
+    def test_updates_agent_state(self):
+        provider = _make_streaming_provider("test content")
+        helix = _make_helix()
+        agent = LLMAgent("a-001", provider, helix, agent_type="research")
+        agent.spawn(0.1)
+        agent.update_position(0.5)
+
+        assert agent.total_tokens_used == 0
+        assert agent.total_processing_time == 0.0
+        assert len(agent.processing_results) == 0
+
+        agent.process_task_streaming(
+            LLMTask(task_id="t1", description="Test"), StreamHandler()
+        )
+
+        assert agent.total_tokens_used > 0
+        assert agent.total_processing_time > 0.0
+        assert len(agent.processing_results) == 1
+
+    def test_emits_events(self):
+        bus = EventBus()
+        bus.enable_history()
+
+        provider = _make_streaming_provider("data")
+        helix = _make_helix()
+        agent = LLMAgent("a-001", provider, helix, agent_type="research", event_bus=bus)
+        agent.spawn(0.1)
+        agent.update_position(0.5)
+
+        agent.process_task_streaming(
+            LLMTask(task_id="t1", description="Test"), StreamHandler()
+        )
+
+        types = [e.event_type for e in bus.history]
+        assert "task.started" in types
+        assert "task.completed" in types
+
+        # Verify streaming flag in event data
+        started = [e for e in bus.history if e.event_type == "task.started"][0]
+        assert started.data["streaming"] is True
+
+    def test_confidence_recorded(self):
+        provider = _make_streaming_provider("a solid analysis with clear evidence")
+        helix = _make_helix()
+        agent = LLMAgent("a-001", provider, helix, agent_type="analysis")
+        agent.spawn(0.1)
+        agent.update_position(0.5)
+
+        result = agent.process_task_streaming(
+            LLMTask(task_id="t1", description="Test"), StreamHandler()
+        )
+
+        assert 0.0 < result.confidence <= 1.0
+        assert len(agent._confidence_history) == 1

--- a/tests/unit/test_streaming.py
+++ b/tests/unit/test_streaming.py
@@ -1,0 +1,247 @@
+"""Tests for the streaming module — types, handlers, and accumulator."""
+
+from __future__ import annotations
+
+import pytest
+
+from felix_agent_sdk.events import EventBus, EventType
+from felix_agent_sdk.providers.types import StreamChunk
+from felix_agent_sdk.streaming import (
+    CallbackStreamHandler,
+    EventBusStreamHandler,
+    StreamAccumulator,
+    StreamEvent,
+    StreamEventType,
+    StreamHandler,
+)
+
+
+# ---------------------------------------------------------------------------
+# StreamEvent
+# ---------------------------------------------------------------------------
+
+
+class TestStreamEvent:
+    def test_construction(self):
+        evt = StreamEvent(
+            agent_id="research-001",
+            event_type=StreamEventType.TOKEN,
+            content="hello",
+        )
+        assert evt.agent_id == "research-001"
+        assert evt.event_type == StreamEventType.TOKEN
+        assert evt.content == "hello"
+        assert evt.accumulated == ""
+        assert evt.token_index == 0
+        assert evt.is_final is False
+        assert isinstance(evt.timestamp, float)
+
+    def test_frozen(self):
+        evt = StreamEvent(agent_id="a", event_type=StreamEventType.TOKEN, content="x")
+        with pytest.raises(AttributeError):
+            evt.content = "y"  # type: ignore[misc]
+
+
+class TestStreamEventType:
+    def test_values(self):
+        assert StreamEventType.TOKEN.value == "token"
+        assert StreamEventType.CHUNK.value == "chunk"
+        assert StreamEventType.RESULT.value == "result"
+        assert StreamEventType.ERROR.value == "error"
+
+
+# ---------------------------------------------------------------------------
+# StreamHandler
+# ---------------------------------------------------------------------------
+
+
+class TestStreamHandler:
+    def test_base_is_noop(self):
+        handler = StreamHandler()
+        evt = StreamEvent(agent_id="a", event_type=StreamEventType.TOKEN, content="x")
+        # Should not raise
+        handler.on_token(evt)
+        handler.on_result(evt)
+        handler.on_error(evt)
+
+    def test_dispatch_routes_token(self):
+        received = []
+
+        class MyHandler(StreamHandler):
+            def on_token(self, event: StreamEvent) -> None:
+                received.append(("token", event.content))
+
+        handler = MyHandler()
+        handler.dispatch(StreamEvent(
+            agent_id="a", event_type=StreamEventType.TOKEN, content="hello"
+        ))
+        assert received == [("token", "hello")]
+
+    def test_dispatch_routes_chunk_to_on_token(self):
+        received = []
+
+        class MyHandler(StreamHandler):
+            def on_token(self, event: StreamEvent) -> None:
+                received.append(event.content)
+
+        handler = MyHandler()
+        handler.dispatch(StreamEvent(
+            agent_id="a", event_type=StreamEventType.CHUNK, content="batch"
+        ))
+        assert received == ["batch"]
+
+    def test_dispatch_routes_result(self):
+        received = []
+
+        class MyHandler(StreamHandler):
+            def on_result(self, event: StreamEvent) -> None:
+                received.append(event.accumulated)
+
+        handler = MyHandler()
+        handler.dispatch(StreamEvent(
+            agent_id="a", event_type=StreamEventType.RESULT,
+            content="last", accumulated="full text", is_final=True,
+        ))
+        assert received == ["full text"]
+
+    def test_dispatch_routes_error(self):
+        received = []
+
+        class MyHandler(StreamHandler):
+            def on_error(self, event: StreamEvent) -> None:
+                received.append(event.content)
+
+        handler = MyHandler()
+        handler.dispatch(StreamEvent(
+            agent_id="a", event_type=StreamEventType.ERROR, content="boom"
+        ))
+        assert received == ["boom"]
+
+
+# ---------------------------------------------------------------------------
+# CallbackStreamHandler
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackStreamHandler:
+    def test_token_callback(self):
+        tokens = []
+        handler = CallbackStreamHandler(on_token=lambda e: tokens.append(e.content))
+        handler.on_token(StreamEvent(
+            agent_id="a", event_type=StreamEventType.TOKEN, content="hi"
+        ))
+        assert tokens == ["hi"]
+
+    def test_result_callback(self):
+        results = []
+        handler = CallbackStreamHandler(on_result=lambda e: results.append(e.accumulated))
+        handler.on_result(StreamEvent(
+            agent_id="a", event_type=StreamEventType.RESULT,
+            content="", accumulated="done", is_final=True,
+        ))
+        assert results == ["done"]
+
+    def test_none_callbacks_are_noop(self):
+        handler = CallbackStreamHandler()
+        # Should not raise
+        handler.on_token(StreamEvent(agent_id="a", event_type=StreamEventType.TOKEN, content="x"))
+        handler.on_result(StreamEvent(agent_id="a", event_type=StreamEventType.RESULT, content="x"))
+        handler.on_error(StreamEvent(agent_id="a", event_type=StreamEventType.ERROR, content="x"))
+
+
+# ---------------------------------------------------------------------------
+# EventBusStreamHandler
+# ---------------------------------------------------------------------------
+
+
+class TestEventBusStreamHandler:
+    def test_token_emits_to_bus(self):
+        bus = EventBus()
+        bus.enable_history()
+        handler = EventBusStreamHandler(bus)
+
+        handler.on_token(StreamEvent(
+            agent_id="research-001", event_type=StreamEventType.TOKEN,
+            content="hello", token_index=1,
+        ))
+
+        assert len(bus.history) == 1
+        assert bus.history[0].event_type == "stream.token"
+        assert bus.history[0].data["content"] == "hello"
+
+    def test_result_emits_to_bus(self):
+        bus = EventBus()
+        bus.enable_history()
+        handler = EventBusStreamHandler(bus)
+
+        handler.on_result(StreamEvent(
+            agent_id="research-001", event_type=StreamEventType.RESULT,
+            content="last", accumulated="hello world", token_index=5,
+            is_final=True, usage={"total_tokens": 50},
+        ))
+
+        assert len(bus.history) == 1
+        assert bus.history[0].event_type == "stream.completed"
+        assert bus.history[0].data["length"] == 11
+        assert bus.history[0].data["token_count"] == 5
+
+
+# ---------------------------------------------------------------------------
+# StreamAccumulator
+# ---------------------------------------------------------------------------
+
+
+class TestStreamAccumulator:
+    def test_accumulates_text(self):
+        received = []
+        handler = CallbackStreamHandler(on_token=lambda e: received.append(e.content))
+
+        acc = StreamAccumulator("agent-001", handler, model="test-model")
+        acc.feed(StreamChunk(text="Hello "))
+        acc.feed(StreamChunk(text="world"))
+        acc.feed(StreamChunk(text="!", is_final=True, usage={"total_tokens": 10}))
+
+        assert acc.accumulated_text == "Hello world!"
+        assert acc.token_count == 3
+        # 2 token events + 1 result event dispatched through handler
+        assert received == ["Hello ", "world"]
+
+    def test_to_completion_result(self):
+        handler = StreamHandler()  # no-op
+        acc = StreamAccumulator("agent-001", handler, model="gpt-4o")
+
+        acc.feed(StreamChunk(text="abc"))
+        acc.feed(StreamChunk(text="def", is_final=True, usage={"total_tokens": 5}))
+
+        result = acc.to_completion_result()
+        assert result.content == "abcdef"
+        assert result.model == "gpt-4o"
+        assert result.usage == {"total_tokens": 5}
+
+    def test_feed_all(self):
+        handler = StreamHandler()
+        acc = StreamAccumulator("agent-001", handler)
+
+        chunks = [
+            StreamChunk(text="a"),
+            StreamChunk(text="b"),
+            StreamChunk(text="c", is_final=True, usage={"total_tokens": 3}),
+        ]
+        acc.feed_all(iter(chunks))
+
+        assert acc.accumulated_text == "abc"
+        assert acc.token_count == 3
+
+    def test_result_event_dispatched_on_final(self):
+        results = []
+        handler = CallbackStreamHandler(on_result=lambda e: results.append(e))
+
+        acc = StreamAccumulator("agent-001", handler)
+        acc.feed(StreamChunk(text="hello"))
+        assert len(results) == 0
+
+        acc.feed(StreamChunk(text="!", is_final=True, usage={"total_tokens": 2}))
+        assert len(results) == 1
+        assert results[0].is_final is True
+        assert results[0].accumulated == "hello!"
+        assert results[0].usage == {"total_tokens": 2}


### PR DESCRIPTION
## Summary

Fills the `streaming/` stub with a complete token-level streaming system.

- **StreamEvent/StreamEventType** — frozen dataclass + enum for token, chunk, result, error events
- **StreamHandler** — base class with `dispatch()` routing to `on_token`/`on_result`/`on_error`
- **CallbackStreamHandler** — simple callable-backed handler
- **EventBusStreamHandler** — re-emits stream events as `stream.token`/`stream.completed` onto EventBus
- **StreamAccumulator** — bridges `provider.stream()` → `StreamChunk` → `StreamEvent`, produces `CompletionResult` for parity with non-streaming path
- **LLMAgent.process_task_streaming(task, handler)** — full streaming processing with identical lifecycle to `process_task()`

## Test plan
- [x] 23 new tests (types, handlers, accumulator, agent streaming integration)
- [x] 737 total tests passing
- [x] `ruff check src/` clean
- [x] 2 new top-level exports: `StreamEvent`, `StreamHandler`

Depends on PR #20 (event system). Contributes to Phase 2.