### PR TITLE
feat(spawning): add dynamic confidence-driven agent spawning

### DIFF
--- a/src/felix_agent_sdk/__init__.py
+++ b/src/felix_agent_sdk/__init__.py
@@ -33,6 +33,7 @@ from felix_agent_sdk.providers import (
 from felix_agent_sdk.communication import CentralPost, Message, MessageType, Spoke
 from felix_agent_sdk.events import EventBus, EventType, FelixEvent
 from felix_agent_sdk.memory import ContextCompressor, KnowledgeStore, TaskMemory
+from felix_agent_sdk.spawning import ConfidenceMonitor, DynamicSpawner
 from felix_agent_sdk.streaming import StreamEvent, StreamHandler
 from felix_agent_sdk.tokens import TokenBudget
 from felix_agent_sdk.utils import configure_logging
@@ -73,6 +74,9 @@ __all__ = [
     "EventBus",
     "EventType",
     "FelixEvent",
+    # Spawning
+    "DynamicSpawner",
+    "ConfidenceMonitor",
     # Streaming
     "StreamEvent",
     "StreamHandler",

--- a/src/felix_agent_sdk/memory/compression.py
+++ b/src/felix_agent_sdk/memory/compression.py
@@ -12,6 +12,8 @@ import hashlib
 import json
 import re
 import time
+
+from felix_agent_sdk.utils.text import STOPWORDS
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional
@@ -91,77 +93,8 @@ class CompressionConfig:
     relevance_threshold: float = 0.3
 
 
-# ------------------------------------------------------------------
-# Stopwords (shared with keyword extraction)
-# ------------------------------------------------------------------
-
-_STOPWORDS: set[str] = {
-    "the",
-    "and",
-    "for",
-    "are",
-    "but",
-    "not",
-    "you",
-    "all",
-    "can",
-    "had",
-    "her",
-    "was",
-    "one",
-    "our",
-    "out",
-    "day",
-    "get",
-    "has",
-    "him",
-    "his",
-    "how",
-    "its",
-    "may",
-    "new",
-    "now",
-    "old",
-    "see",
-    "two",
-    "who",
-    "boy",
-    "did",
-    "man",
-    "she",
-    "use",
-    "way",
-    "where",
-    "much",
-    "your",
-    "from",
-    "they",
-    "know",
-    "want",
-    "been",
-    "good",
-    "much",
-    "some",
-    "time",
-    "very",
-    "when",
-    "come",
-    "here",
-    "just",
-    "like",
-    "long",
-    "make",
-    "many",
-    "over",
-    "such",
-    "take",
-    "than",
-    "them",
-    "well",
-    "were",
-    "will",
-    "with",
-}
+# Stopwords imported from shared utils
+_STOPWORDS = STOPWORDS
 
 
 # ------------------------------------------------------------------

--- a/src/felix_agent_sdk/memory/task_memory.py
+++ b/src/felix_agent_sdk/memory/task_memory.py
@@ -17,6 +17,8 @@ from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Optional
 
+from felix_agent_sdk.utils.text import STOPWORDS
+
 from felix_agent_sdk.memory.backends.base import BaseBackend
 from felix_agent_sdk.memory.backends.sqlite import SQLiteBackend
 
@@ -49,47 +51,8 @@ class TaskComplexity(Enum):
 # Helpers
 # ------------------------------------------------------------------
 
-_STOPWORDS: set[str] = {
-    "the",
-    "and",
-    "for",
-    "are",
-    "but",
-    "not",
-    "you",
-    "all",
-    "can",
-    "had",
-    "her",
-    "was",
-    "one",
-    "our",
-    "out",
-    "day",
-    "get",
-    "has",
-    "him",
-    "his",
-    "how",
-    "its",
-    "may",
-    "new",
-    "now",
-    "old",
-    "see",
-    "two",
-    "who",
-    "boy",
-    "did",
-    "man",
-    "she",
-    "use",
-    "way",
-    "oil",
-    "sit",
-    "set",
-    "run",
-}
+# Stopwords imported from shared utils
+_STOPWORDS = STOPWORDS
 
 
 def _get_enum_value(value: Any) -> str:

--- a/src/felix_agent_sdk/spawning/__init__.py
+++ b/src/felix_agent_sdk/spawning/__init__.py
@@ -1,10 +1,23 @@
 """Felix dynamic team adaptation.
 
 Confidence-driven agent spawning that adapts team composition in real time.
-Planned exports: DynamicSpawning, ConfidenceMonitor, ContentAnalyzer,
-TeamSizeOptimizer.
-
-Status: Stub — implementation in feat/agents branch.
 """
 
-__all__: list[str] = []
+from felix_agent_sdk.spawning.confidence_monitor import (
+    ConfidenceMonitor,
+    ConfidenceStatus,
+    SpawnRecommendation,
+)
+from felix_agent_sdk.spawning.content_analyzer import ContentAnalyzer, CoverageReport
+from felix_agent_sdk.spawning.optimizer import TeamSizeOptimizer
+from felix_agent_sdk.spawning.spawner import DynamicSpawner
+
+__all__ = [
+    "ConfidenceMonitor",
+    "ConfidenceStatus",
+    "SpawnRecommendation",
+    "ContentAnalyzer",
+    "CoverageReport",
+    "TeamSizeOptimizer",
+    "DynamicSpawner",
+]

--- a/src/felix_agent_sdk/spawning/confidence_monitor.py
+++ b/src/felix_agent_sdk/spawning/confidence_monitor.py
@@ -1,0 +1,153 @@
+"""Confidence monitoring for dynamic spawning decisions.
+
+Tracks per-agent and team-wide confidence trends, detects stagnation,
+and recommends whether the system should spawn, hold, or prune agents.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List
+
+
+class SpawnRecommendation(str, Enum):
+    """What the monitor recommends the spawner do."""
+
+    SPAWN = "spawn"
+    HOLD = "hold"
+    PRUNE = "prune"
+
+
+@dataclass(frozen=True)
+class ConfidenceStatus:
+    """Snapshot of the team's confidence health."""
+
+    team_average: float
+    trend: str  # "rising", "falling", "stable"
+    gap_to_threshold: float
+    is_stagnating: bool
+    recommendation: SpawnRecommendation
+
+
+# If the team average is more than this below the threshold, spawn
+# immediately regardless of trend.
+_CRITICAL_GAP = 0.2
+
+# Decimal places used when rounding confidence values in status reports.
+_REPORT_PRECISION = 4
+
+
+class ConfidenceMonitor:
+    """Track team confidence and decide whether spawning is warranted.
+
+    The monitor maintains a sliding window of per-agent confidence
+    values and computes team-level statistics each time :meth:`update`
+    is called.
+
+    Args:
+        threshold: Team average confidence below which spawning is
+            recommended.
+        stagnation_window: Number of consecutive updates with
+            less than *stagnation_delta* improvement before the
+            team is considered stagnating.
+        stagnation_delta: Minimum improvement per update to avoid
+            stagnation.
+    """
+
+    def __init__(
+        self,
+        threshold: float = 0.80,
+        stagnation_window: int = 3,
+        stagnation_delta: float = 0.01,
+    ) -> None:
+        self._threshold = threshold
+        self._stagnation_window = stagnation_window
+        self._stagnation_delta = stagnation_delta
+
+        self._agent_history: Dict[str, List[float]] = defaultdict(list)
+        self._team_averages: List[float] = []
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def update(self, agent_id: str, confidence: float) -> None:
+        """Record a new confidence observation for *agent_id*."""
+        self._agent_history[agent_id].append(confidence)
+
+    def record_round(self, confidences: Dict[str, float]) -> None:
+        """Record a full round of confidence observations.
+
+        Also updates the team average history for trend detection.
+        """
+        for agent_id, confidence in confidences.items():
+            self.update(agent_id, confidence)
+
+        if confidences:
+            avg = sum(confidences.values()) / len(confidences)
+            self._team_averages.append(avg)
+
+    def should_spawn(self) -> bool:
+        """Return ``True`` if the team would benefit from more agents."""
+        return self.get_status().recommendation == SpawnRecommendation.SPAWN
+
+    def get_status(self) -> ConfidenceStatus:
+        """Compute current confidence status and spawn recommendation."""
+        avg = self._current_average()
+        trend = self._compute_trend()
+        gap = self._threshold - avg
+        stagnating = self._is_stagnating()
+        rec = self._decide(avg, trend, gap, stagnating)
+
+        return ConfidenceStatus(
+            team_average=round(avg, _REPORT_PRECISION),
+            trend=trend,
+            gap_to_threshold=round(max(gap, 0.0), _REPORT_PRECISION),
+            is_stagnating=stagnating,
+            recommendation=rec,
+        )
+
+    def _decide(
+        self, avg: float, trend: str, gap: float, stagnating: bool
+    ) -> SpawnRecommendation:
+        """Pure decision function: given metrics, return a recommendation."""
+        if avg >= self._threshold:
+            return SpawnRecommendation.HOLD
+        if stagnating or trend == "falling" or gap > _CRITICAL_GAP:
+            return SpawnRecommendation.SPAWN
+        return SpawnRecommendation.HOLD
+
+    def reset(self) -> None:
+        """Clear all tracked state."""
+        self._agent_history.clear()
+        self._team_averages.clear()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _current_average(self) -> float:
+        if not self._team_averages:
+            return 0.0
+        return self._team_averages[-1]
+
+    def _compute_trend(self) -> str:
+        avgs = self._team_averages
+        if len(avgs) < 2:
+            return "stable"
+        delta = avgs[-1] - avgs[-2]
+        if delta > self._stagnation_delta:
+            return "rising"
+        elif delta < -self._stagnation_delta:
+            return "falling"
+        return "stable"
+
+    def _is_stagnating(self) -> bool:
+        avgs = self._team_averages
+        if len(avgs) < self._stagnation_window:
+            return False
+        window = avgs[-self._stagnation_window:]
+        total_change = abs(window[-1] - window[0])
+        return total_change < self._stagnation_delta

--- a/src/felix_agent_sdk/spawning/content_analyzer.py
+++ b/src/felix_agent_sdk/spawning/content_analyzer.py
@@ -1,0 +1,127 @@
+"""Content gap analysis for dynamic spawning decisions.
+
+Examines agent outputs to identify topic coverage gaps and recommend
+which agent type would best address them.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Set
+
+# Words ignored during keyword extraction
+_STOPWORDS: Set[str] = {
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "shall", "can", "need", "must", "to", "of",
+    "in", "for", "on", "with", "at", "by", "from", "as", "into", "about",
+    "this", "that", "these", "those", "it", "its", "not", "no", "and",
+    "or", "but", "if", "so", "than", "too", "very", "just", "also",
+}
+
+# Minimum keyword length after stopword removal
+_MIN_KEYWORD_LEN = 3
+
+# Agent type recommendation thresholds
+_LOW_COVERAGE = 0.3
+_MID_COVERAGE = 0.6
+
+
+@dataclass(frozen=True)
+class CoverageReport:
+    """Result of content gap analysis.
+
+    Attributes:
+        topics_covered: Keywords extracted from agent outputs.
+        topics_sparse: Keywords that appear in fewer than 2 outputs.
+        coverage_score: Ratio of well-covered topics to total topics.
+        recommended_type: The agent type best suited to fill gaps.
+    """
+
+    topics_covered: Set[str] = field(default_factory=set)
+    topics_sparse: Set[str] = field(default_factory=set)
+    coverage_score: float = 0.0
+    recommended_type: str = "research"
+
+
+class ContentAnalyzer:
+    """Analyse agent outputs to identify coverage gaps.
+
+    Uses keyword extraction and topic overlap to determine whether
+    the team's outputs collectively cover the problem space or if
+    specific agent types are needed to fill gaps.
+    """
+
+    def analyze_coverage(self, results: List[Dict[str, Any]]) -> CoverageReport:
+        """Analyse a list of agent result dicts for topic coverage.
+
+        Each dict should have at least ``content`` (str) and
+        ``agent_type`` (str) keys — matching the shape of
+        ``LLMResult`` position_info dicts or simple test dicts.
+
+        Returns:
+            :class:`CoverageReport` with coverage metrics.
+        """
+        if not results:
+            return CoverageReport()
+
+        all_keywords: Set[str] = set()
+        per_result_keywords: List[Set[str]] = []
+
+        for r in results:
+            content = r.get("content", "")
+            kw = self._extract_keywords(content)
+            all_keywords.update(kw)
+            per_result_keywords.append(kw)
+
+        # A topic is "sparse" if it appears in fewer than 2 results
+        topic_counts: Dict[str, int] = {}
+        for kw_set in per_result_keywords:
+            for kw in kw_set:
+                topic_counts[kw] = topic_counts.get(kw, 0) + 1
+
+        sparse = {kw for kw, count in topic_counts.items() if count < 2}
+        covered = all_keywords - sparse
+
+        score = len(covered) / max(len(all_keywords), 1)
+        recommended = self._recommend_type(score, results)
+
+        return CoverageReport(
+            topics_covered=covered,
+            topics_sparse=sparse,
+            coverage_score=round(score, 4),
+            recommended_type=recommended,
+        )
+
+    def recommend_agent_type(self, coverage: CoverageReport) -> str:
+        """Return the agent type string from a coverage report."""
+        return coverage.recommended_type
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _extract_keywords(self, text: str) -> Set[str]:
+        """Extract meaningful keywords from text."""
+        words = re.findall(r"[a-zA-Z]+", text.lower())
+        return {
+            w for w in words
+            if w not in _STOPWORDS and len(w) >= _MIN_KEYWORD_LEN
+        }
+
+    def _recommend_type(
+        self, score: float, results: List[Dict[str, Any]]
+    ) -> str:
+        """Decide which agent type to spawn based on coverage score."""
+        if score < _LOW_COVERAGE:
+            return "research"
+        if score < _MID_COVERAGE:
+            # Check if we're light on analysis
+            types = [r.get("agent_type", "") for r in results]
+            analysis_count = sum(1 for t in types if t == "analysis")
+            if analysis_count < 2:
+                return "analysis"
+            return "research"
+        # High coverage — add a critic to validate
+        return "critic"

--- a/src/felix_agent_sdk/spawning/content_analyzer.py
+++ b/src/felix_agent_sdk/spawning/content_analyzer.py
@@ -10,15 +10,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Set
 
-# Words ignored during keyword extraction
-_STOPWORDS: Set[str] = {
-    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
-    "have", "has", "had", "do", "does", "did", "will", "would", "could",
-    "should", "may", "might", "shall", "can", "need", "must", "to", "of",
-    "in", "for", "on", "with", "at", "by", "from", "as", "into", "about",
-    "this", "that", "these", "those", "it", "its", "not", "no", "and",
-    "or", "but", "if", "so", "than", "too", "very", "just", "also",
-}
+from felix_agent_sdk.utils.text import STOPWORDS
 
 # Minimum keyword length after stopword removal
 _MIN_KEYWORD_LEN = 3
@@ -107,7 +99,7 @@ class ContentAnalyzer:
         words = re.findall(r"[a-zA-Z]+", text.lower())
         return {
             w for w in words
-            if w not in _STOPWORDS and len(w) >= _MIN_KEYWORD_LEN
+            if w not in STOPWORDS and len(w) >= _MIN_KEYWORD_LEN
         }
 
     def _recommend_type(

--- a/src/felix_agent_sdk/spawning/optimizer.py
+++ b/src/felix_agent_sdk/spawning/optimizer.py
@@ -1,0 +1,75 @@
+"""Team size optimisation heuristic.
+
+Recommends optimal team size based on task complexity signals and
+current result quality.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+# Base team size for a simple task
+_BASE_TEAM_SIZE = 3
+
+# Each complexity signal adds this many agents
+_SIGNAL_INCREMENT = 1
+
+# Hard cap to prevent runaway growth
+_MAX_TEAM_SIZE = 15
+
+
+class TeamSizeOptimizer:
+    """Heuristic recommender for team size.
+
+    Considers task description length, topic breadth (keyword count),
+    and current confidence spread to suggest an appropriate team size.
+
+    Args:
+        min_size: Minimum team size to recommend.
+        max_size: Maximum team size to recommend.
+    """
+
+    def __init__(self, min_size: int = 3, max_size: int = _MAX_TEAM_SIZE) -> None:
+        self._min_size = min_size
+        self._max_size = max_size
+
+    def recommend_team_size(
+        self,
+        task_description: str,
+        current_results: List[Dict[str, Any]] | None = None,
+    ) -> int:
+        """Return a recommended team size.
+
+        Args:
+            task_description: The task text (length is a complexity signal).
+            current_results: Existing results (optional). Each dict should
+                have ``confidence`` (float) and ``content`` (str) keys.
+
+        Returns:
+            Recommended team size clamped to [min_size, max_size].
+        """
+        size = _BASE_TEAM_SIZE
+
+        # Signal 1: long task descriptions suggest complexity
+        if len(task_description) > 200:
+            size += _SIGNAL_INCREMENT
+        if len(task_description) > 500:
+            size += _SIGNAL_INCREMENT
+
+        # Signal 2: low average confidence from existing results
+        if current_results:
+            confidences = [r.get("confidence", 0.5) for r in current_results]
+            avg_conf = sum(confidences) / len(confidences)
+            if avg_conf < 0.5:
+                size += _SIGNAL_INCREMENT * 2
+            elif avg_conf < 0.7:
+                size += _SIGNAL_INCREMENT
+
+        # Signal 3: wide confidence spread suggests disagreement
+        if current_results and len(current_results) >= 2:
+            confidences = [r.get("confidence", 0.5) for r in current_results]
+            spread = max(confidences) - min(confidences)
+            if spread > 0.3:
+                size += _SIGNAL_INCREMENT
+
+        return max(self._min_size, min(self._max_size, size))

--- a/src/felix_agent_sdk/spawning/spawner.py
+++ b/src/felix_agent_sdk/spawning/spawner.py
@@ -1,0 +1,164 @@
+"""Dynamic spawner — orchestrates confidence-driven agent creation.
+
+Combines :class:`ConfidenceMonitor` and :class:`ContentAnalyzer` to
+decide whether and what type of agent to spawn each round.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from felix_agent_sdk.agents.factory import AgentFactory
+from felix_agent_sdk.agents.llm_agent import LLMAgent, LLMResult
+from felix_agent_sdk.communication.spoke import SpokeManager
+from felix_agent_sdk.events.bus import EventBus
+from felix_agent_sdk.events.mixins import EventEmitterMixin
+from felix_agent_sdk.events.types import EventType
+from felix_agent_sdk.spawning.confidence_monitor import ConfidenceMonitor
+from felix_agent_sdk.spawning.content_analyzer import ContentAnalyzer
+
+logger = logging.getLogger(__name__)
+
+
+class DynamicSpawner(EventEmitterMixin):
+    """Confidence-driven agent spawner.
+
+    Called once per round by the workflow runner. Consults the
+    :class:`ConfidenceMonitor` and :class:`ContentAnalyzer` to decide
+    whether to create new agents. Newly spawned agents are connected
+    to the hub via the spoke manager and returned to the caller so
+    they participate in subsequent rounds.
+
+    Args:
+        factory: Agent factory for creating new agents.
+        spoke_mgr: Spoke manager for hub connectivity.
+        monitor: Confidence monitor instance.
+        analyzer: Content analyzer instance.
+        max_spawned: Maximum number of agents to spawn across the
+            entire workflow.
+        event_bus: Optional event bus for observability.
+    """
+
+    def __init__(
+        self,
+        factory: AgentFactory,
+        spoke_mgr: SpokeManager,
+        monitor: Optional[ConfidenceMonitor] = None,
+        analyzer: Optional[ContentAnalyzer] = None,
+        max_spawned: int = 3,
+        event_bus: Optional[EventBus] = None,
+    ) -> None:
+        self._factory = factory
+        self._spoke_mgr = spoke_mgr
+        self._monitor = monitor or ConfidenceMonitor()
+        self._analyzer = analyzer or ContentAnalyzer()
+        self._max_spawned = max_spawned
+        self._total_spawned = 0
+        if event_bus is not None:
+            self.set_event_bus(event_bus)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def check_and_spawn(
+        self,
+        agents: List[LLMAgent],
+        round_results: List[LLMResult],
+        current_time: float,
+    ) -> List[LLMAgent]:
+        """Evaluate whether to spawn and return any new agents.
+
+        Args:
+            agents: Current team of agents.
+            round_results: Results from the most recent round.
+            current_time: Current helix time parameter.
+
+        Returns:
+            List of newly spawned agents (empty if none spawned).
+        """
+        if self._total_spawned >= self._max_spawned:
+            return []
+
+        if not round_results:
+            return []
+
+        # Feed confidence data to the monitor
+        confidences: Dict[str, float] = {
+            r.agent_id: r.confidence for r in round_results
+        }
+        self._monitor.record_round(confidences)
+
+        # Check if spawning is recommended
+        if not self._monitor.should_spawn():
+            return []
+
+        # Determine what type of agent to spawn
+        result_dicts = self._results_to_dicts(round_results)
+        coverage = self._analyzer.analyze_coverage(result_dicts)
+        agent_type = coverage.recommended_type
+
+        # Spawn
+        status = self._monitor.get_status()
+        self.emit_event(
+            EventType.SPAWN_TRIGGERED,
+            {
+                "agent_type": agent_type,
+                "reason": status.recommendation.value,
+                "team_average": status.team_average,
+                "gap": status.gap_to_threshold,
+                "trend": status.trend,
+            },
+        )
+
+        spawn_time = min(current_time, 0.9)
+        agent = self._factory.create_agent(
+            agent_type=agent_type,
+            spawn_time=spawn_time,
+        )
+        if getattr(self, "_event_bus", None) is not None:
+            agent.set_event_bus(self._event_bus)  # type: ignore[arg-type]
+        self._spoke_mgr.create_spoke(agent.agent_id, agent=agent)
+        self._total_spawned += 1
+
+        logger.info(
+            "Dynamic spawn: %s agent %s (total spawned: %d/%d)",
+            agent_type,
+            agent.agent_id,
+            self._total_spawned,
+            self._max_spawned,
+        )
+
+        self.emit_event(
+            EventType.SPAWN_COMPLETED,
+            {
+                "agent_id": agent.agent_id,
+                "agent_type": agent_type,
+                "spawn_time": spawn_time,
+                "total_spawned": self._total_spawned,
+            },
+        )
+
+        return [agent]
+
+    @property
+    def total_spawned(self) -> int:
+        """Number of agents spawned so far."""
+        return self._total_spawned
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _results_to_dicts(results: List[LLMResult]) -> List[Dict[str, Any]]:
+        """Convert LLMResult list to simple dicts for the analyzer."""
+        return [
+            {
+                "content": r.content,
+                "agent_type": r.position_info.get("agent_type", ""),
+                "confidence": r.confidence,
+            }
+            for r in results
+        ]

--- a/src/felix_agent_sdk/utils/text.py
+++ b/src/felix_agent_sdk/utils/text.py
@@ -1,0 +1,35 @@
+"""Shared text processing utilities."""
+
+from __future__ import annotations
+
+# Common English stopwords used by keyword extraction across the SDK.
+# Used by: memory/compression.py, memory/task_memory.py, spawning/content_analyzer.py
+STOPWORDS: frozenset[str] = frozenset({
+    # Articles / determiners
+    "the", "a", "an", "this", "that", "these", "those",
+    # Pronouns
+    "it", "its", "he", "him", "his", "she", "her", "you", "your",
+    "our", "we", "they", "them",
+    # Be-verbs
+    "is", "are", "was", "were", "be", "been", "being",
+    # Have-verbs
+    "have", "has", "had",
+    # Do-verbs
+    "do", "does", "did",
+    # Modals
+    "will", "would", "could", "should", "may", "might", "shall", "can",
+    "need", "must",
+    # Prepositions
+    "to", "of", "in", "for", "on", "with", "at", "by", "from", "as",
+    "into", "about", "over",
+    # Conjunctions
+    "and", "or", "but", "if", "so", "than",
+    # Adverbs / misc
+    "not", "no", "too", "very", "just", "also", "here", "now", "how",
+    "all", "one", "two", "new", "old", "much", "many", "some", "such",
+    "well", "long", "good", "time", "make", "take", "come", "like",
+    "when", "where", "know", "want",
+    # Short common words (from memory module lists)
+    "out", "day", "get", "see", "who", "boy", "man", "use", "way",
+    "oil", "sit", "set", "run",
+})

--- a/src/felix_agent_sdk/workflows/config.py
+++ b/src/felix_agent_sdk/workflows/config.py
@@ -63,6 +63,8 @@ class WorkflowConfig:
     max_agents: int = 10
     enable_context_compression: bool = True
     compression_config: Optional[CompressionConfig] = None
+    enable_dynamic_spawning: bool = False
+    max_dynamic_agents: int = 3
 
 
 # ------------------------------------------------------------------

--- a/src/felix_agent_sdk/workflows/runner.py
+++ b/src/felix_agent_sdk/workflows/runner.py
@@ -25,6 +25,7 @@ from felix_agent_sdk.events.bus import EventBus
 from felix_agent_sdk.events.mixins import EventEmitterMixin
 from felix_agent_sdk.events.types import EventType
 from felix_agent_sdk.providers.base import BaseProvider
+from felix_agent_sdk.spawning.spawner import DynamicSpawner
 from felix_agent_sdk.workflows.config import WorkflowConfig, WorkflowResult
 from felix_agent_sdk.workflows.context_builder import CollaborativeContextBuilder
 from felix_agent_sdk.workflows.synthesizer import WorkflowSynthesizer
@@ -84,6 +85,15 @@ class FelixWorkflow(EventEmitterMixin):
         builder = CollaborativeContextBuilder()
         all_results: list[LLMResult] = []
 
+        spawner: Optional[DynamicSpawner] = None
+        if self._config.enable_dynamic_spawning:
+            spawner = DynamicSpawner(
+                factory=self._factory,
+                spoke_mgr=spoke_mgr,
+                max_spawned=self._config.max_dynamic_agents,
+                event_bus=getattr(self, "_event_bus", None),
+            )
+
         self.emit_event(
             EventType.WORKFLOW_STARTED,
             {
@@ -132,8 +142,12 @@ class FelixWorkflow(EventEmitterMixin):
                     },
                 )
 
-                # Dynamic spawning hook (no-op for now)
-                self._check_dynamic_spawning(agents, round_results)
+                # Dynamic spawning
+                if spawner is not None:
+                    new_agents = spawner.check_and_spawn(
+                        agents, round_results, current_time
+                    )
+                    agents.extend(new_agents)
 
                 # Convergence check
                 if round_results and avg_confidence >= self._config.confidence_threshold:
@@ -280,21 +294,6 @@ class FelixWorkflow(EventEmitterMixin):
         spoke_mgr.process_all_messages()
 
         return round_results
-
-    # ------------------------------------------------------------------
-    # Dynamic spawning hook
-    # ------------------------------------------------------------------
-
-    def _check_dynamic_spawning(
-        self,
-        agents: list[LLMAgent],
-        round_results: list[LLMResult],
-    ) -> None:
-        """Hook for confidence-driven dynamic spawning.
-
-        Currently a no-op. Will be wired when the ``spawning/`` module
-        is implemented.
-        """
 
     # ------------------------------------------------------------------
     # Convenience function

--- a/tests/unit/test_confidence_monitor.py
+++ b/tests/unit/test_confidence_monitor.py
@@ -1,0 +1,94 @@
+"""Tests for ConfidenceMonitor."""
+
+from __future__ import annotations
+
+from felix_agent_sdk.spawning.confidence_monitor import (
+    ConfidenceMonitor,
+    SpawnRecommendation,
+)
+
+
+class TestConfidenceMonitorBasics:
+    def test_no_data_returns_hold(self):
+        mon = ConfidenceMonitor(threshold=0.8)
+        status = mon.get_status()
+        assert status.team_average == 0.0
+        assert status.recommendation == SpawnRecommendation.SPAWN  # big gap
+
+    def test_above_threshold_holds(self):
+        mon = ConfidenceMonitor(threshold=0.7)
+        mon.record_round({"a": 0.8, "b": 0.9})
+        assert mon.get_status().recommendation == SpawnRecommendation.HOLD
+
+    def test_below_threshold_falling_spawns(self):
+        mon = ConfidenceMonitor(threshold=0.8)
+        mon.record_round({"a": 0.7, "b": 0.6})
+        mon.record_round({"a": 0.5, "b": 0.4})
+        status = mon.get_status()
+        assert status.trend == "falling"
+        assert status.recommendation == SpawnRecommendation.SPAWN
+
+    def test_should_spawn_reflects_status(self):
+        mon = ConfidenceMonitor(threshold=0.9)
+        mon.record_round({"a": 0.3})
+        assert mon.should_spawn() is True
+
+
+class TestConfidenceMonitorTrend:
+    def test_rising(self):
+        mon = ConfidenceMonitor(threshold=0.9, stagnation_delta=0.01)
+        mon.record_round({"a": 0.4})
+        mon.record_round({"a": 0.6})
+        assert mon.get_status().trend == "rising"
+
+    def test_falling(self):
+        mon = ConfidenceMonitor(threshold=0.9, stagnation_delta=0.01)
+        mon.record_round({"a": 0.6})
+        mon.record_round({"a": 0.4})
+        assert mon.get_status().trend == "falling"
+
+    def test_stable(self):
+        mon = ConfidenceMonitor(threshold=0.9, stagnation_delta=0.05)
+        mon.record_round({"a": 0.5})
+        mon.record_round({"a": 0.51})
+        assert mon.get_status().trend == "stable"
+
+
+class TestConfidenceMonitorStagnation:
+    def test_stagnation_detected(self):
+        mon = ConfidenceMonitor(threshold=0.8, stagnation_window=3, stagnation_delta=0.02)
+        mon.record_round({"a": 0.50})
+        mon.record_round({"a": 0.50})
+        mon.record_round({"a": 0.51})
+        status = mon.get_status()
+        assert status.is_stagnating is True
+        assert status.recommendation == SpawnRecommendation.SPAWN
+
+    def test_no_stagnation_if_improving(self):
+        mon = ConfidenceMonitor(threshold=0.8, stagnation_window=3, stagnation_delta=0.02)
+        mon.record_round({"a": 0.50})
+        mon.record_round({"a": 0.55})
+        mon.record_round({"a": 0.60})
+        assert mon.get_status().is_stagnating is False
+
+    def test_not_enough_data_for_stagnation(self):
+        mon = ConfidenceMonitor(stagnation_window=5)
+        mon.record_round({"a": 0.5})
+        mon.record_round({"a": 0.5})
+        assert mon.get_status().is_stagnating is False
+
+
+class TestConfidenceMonitorCriticalGap:
+    def test_large_gap_spawns_immediately(self):
+        mon = ConfidenceMonitor(threshold=0.8)
+        mon.record_round({"a": 0.3})  # gap = 0.5 > 0.2
+        assert mon.get_status().recommendation == SpawnRecommendation.SPAWN
+
+
+class TestConfidenceMonitorReset:
+    def test_reset_clears_state(self):
+        mon = ConfidenceMonitor(threshold=0.8)
+        mon.record_round({"a": 0.5})
+        mon.reset()
+        status = mon.get_status()
+        assert status.team_average == 0.0

--- a/tests/unit/test_content_analyzer.py
+++ b/tests/unit/test_content_analyzer.py
@@ -1,0 +1,86 @@
+"""Tests for ContentAnalyzer."""
+
+from __future__ import annotations
+
+from felix_agent_sdk.spawning.content_analyzer import ContentAnalyzer
+
+
+class TestContentAnalyzerBasics:
+    def test_empty_results(self):
+        analyzer = ContentAnalyzer()
+        report = analyzer.analyze_coverage([])
+        assert report.coverage_score == 0.0
+        assert report.recommended_type == "research"
+
+    def test_single_result_all_sparse(self):
+        analyzer = ContentAnalyzer()
+        report = analyzer.analyze_coverage([
+            {"content": "Renewable energy solar panels efficiency", "agent_type": "research"}
+        ])
+        # All topics appear only once → all sparse → coverage 0
+        assert report.coverage_score == 0.0
+        assert len(report.topics_sparse) > 0
+        assert report.recommended_type == "research"
+
+    def test_overlapping_results_increase_coverage(self):
+        analyzer = ContentAnalyzer()
+        report = analyzer.analyze_coverage([
+            {"content": "Solar energy production increases globally", "agent_type": "research"},
+            {"content": "Solar energy adoption in developing markets", "agent_type": "research"},
+        ])
+        # "solar" and "energy" appear in both → covered
+        assert report.coverage_score > 0.0
+        assert "solar" in report.topics_covered
+        assert "energy" in report.topics_covered
+
+
+class TestContentAnalyzerRecommendation:
+    def test_low_coverage_recommends_research(self):
+        analyzer = ContentAnalyzer()
+        report = analyzer.analyze_coverage([
+            {"content": "Quantum computing basics", "agent_type": "research"},
+        ])
+        assert report.recommended_type == "research"
+
+    def test_high_coverage_recommends_critic(self):
+        analyzer = ContentAnalyzer()
+        # All words overlap → high coverage
+        report = analyzer.analyze_coverage([
+            {"content": "analysis results data findings", "agent_type": "research"},
+            {"content": "analysis results data findings", "agent_type": "analysis"},
+            {"content": "analysis results data findings", "agent_type": "analysis"},
+        ])
+        assert report.coverage_score > 0.6
+        assert report.recommended_type == "critic"
+
+    def test_mid_coverage_light_analysis_recommends_analysis(self):
+        analyzer = ContentAnalyzer()
+        report = analyzer.analyze_coverage([
+            {"content": "renewable energy solar capacity growth data", "agent_type": "research"},
+            {"content": "renewable energy market trends growth", "agent_type": "research"},
+        ])
+        # Mid coverage, no analysis agents → should recommend analysis
+        if 0.3 <= report.coverage_score < 0.6:
+            assert report.recommended_type == "analysis"
+
+
+class TestContentAnalyzerKeywordExtraction:
+    def test_stopwords_removed(self):
+        analyzer = ContentAnalyzer()
+        report = analyzer.analyze_coverage([
+            {"content": "the quick brown fox is very fast", "agent_type": "research"},
+            {"content": "the quick brown fox jumps over", "agent_type": "research"},
+        ])
+        assert "the" not in report.topics_covered
+        assert "is" not in report.topics_covered
+        assert "quick" in report.topics_covered
+
+    def test_short_words_removed(self):
+        analyzer = ContentAnalyzer()
+        report = analyzer.analyze_coverage([
+            {"content": "an AI ML model for NLP", "agent_type": "research"},
+            {"content": "an AI ML model works", "agent_type": "research"},
+        ])
+        # "ai", "ml" are < 3 chars → removed
+        assert "ai" not in report.topics_covered
+        assert "model" in report.topics_covered

--- a/tests/unit/test_dynamic_spawner.py
+++ b/tests/unit/test_dynamic_spawner.py
@@ -1,0 +1,151 @@
+"""Tests for DynamicSpawner integration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from felix_agent_sdk.agents.factory import AgentFactory
+from felix_agent_sdk.agents.llm_agent import LLMResult
+from felix_agent_sdk.communication.central_post import CentralPost
+from felix_agent_sdk.communication.spoke import SpokeManager
+from felix_agent_sdk.core.helix import HelixConfig
+from felix_agent_sdk.events import EventBus, EventType
+from felix_agent_sdk.providers.base import BaseProvider
+from felix_agent_sdk.providers.types import CompletionResult
+from felix_agent_sdk.spawning import ConfidenceMonitor, DynamicSpawner
+from felix_agent_sdk.workflows.config import WorkflowConfig
+from felix_agent_sdk import run_felix_workflow
+
+
+def _mock_provider() -> BaseProvider:
+    provider = MagicMock(spec=BaseProvider)
+    provider.complete.return_value = CompletionResult(
+        content="Low confidence filler text.",
+        model="mock",
+        usage={"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30},
+    )
+    provider.count_tokens.return_value = 20
+    return provider
+
+
+def _make_low_confidence_result(agent_id: str = "agent-001") -> LLMResult:
+    return LLMResult(
+        agent_id=agent_id,
+        task_id="t1",
+        content="Uncertain findings with weak evidence.",
+        position_info={"phase": "exploration", "agent_type": "research"},
+        completion_result=CompletionResult(
+            content="text", model="mock",
+            usage={"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
+        ),
+        processing_time=0.1,
+        confidence=0.3,
+        temperature_used=0.8,
+        token_budget_used=20,
+    )
+
+
+class TestDynamicSpawner:
+    def _setup(self, max_spawned: int = 3, event_bus: EventBus | None = None):
+        provider = _mock_provider()
+        hub = CentralPost(max_agents=20)
+        spoke_mgr = SpokeManager(hub=hub)
+        factory = AgentFactory(provider, helix_config=HelixConfig.default())
+        monitor = ConfidenceMonitor(threshold=0.8)
+        spawner = DynamicSpawner(
+            factory=factory,
+            spoke_mgr=spoke_mgr,
+            monitor=monitor,
+            max_spawned=max_spawned,
+            event_bus=event_bus,
+        )
+        return spawner, spoke_mgr, hub
+
+    def test_spawns_when_confidence_low(self):
+        spawner, _, hub = self._setup()
+        results = [_make_low_confidence_result("a1"), _make_low_confidence_result("a2")]
+        # Large gap to threshold triggers spawn on first round
+        new1 = spawner.check_and_spawn([], results, 0.3)
+        assert len(new1) == 1
+        new2 = spawner.check_and_spawn([], results, 0.5)
+        assert len(new2) == 1
+        assert spawner.total_spawned == 2
+
+    def test_no_spawn_when_empty_results(self):
+        spawner, _, _ = self._setup()
+        new = spawner.check_and_spawn([], [], 0.3)
+        assert len(new) == 0
+
+    def test_respects_max_spawned(self):
+        spawner, _, _ = self._setup(max_spawned=1)
+        results = [_make_low_confidence_result()]
+        # First round seeds the monitor
+        spawner.check_and_spawn([], results, 0.3)
+        # Second round triggers spawn
+        spawner.check_and_spawn([], results, 0.5)
+        assert spawner.total_spawned == 1
+        # Third round — already at max
+        new = spawner.check_and_spawn([], results, 0.7)
+        assert len(new) == 0
+        assert spawner.total_spawned == 1
+
+    def test_emits_events(self):
+        bus = EventBus()
+        bus.enable_history()
+        spawner, _, _ = self._setup(event_bus=bus)
+
+        results = [_make_low_confidence_result()]
+        spawner.check_and_spawn([], results, 0.3)
+        spawner.check_and_spawn([], results, 0.5)
+
+        types = [e.event_type for e in bus.history]
+        assert "spawn.triggered" in types
+        assert "spawn.completed" in types
+
+    def test_spawn_completed_has_agent_id(self):
+        bus = EventBus()
+        bus.enable_history()
+        spawner, _, _ = self._setup(event_bus=bus)
+
+        results = [_make_low_confidence_result()]
+        spawner.check_and_spawn([], results, 0.3)
+
+        completed = [e for e in bus.history if e.event_type == "spawn.completed"]
+        assert len(completed) == 1
+        assert "agent_id" in completed[0].data
+        assert "agent_type" in completed[0].data
+
+
+class TestDynamicSpawningWorkflowIntegration:
+    """Test that enable_dynamic_spawning works end-to-end in a workflow."""
+
+    def test_workflow_with_dynamic_spawning(self):
+        bus = EventBus()
+        bus.enable_history()
+
+        provider = _mock_provider()
+        config = WorkflowConfig(
+            max_rounds=3,
+            confidence_threshold=0.99,  # unreachable → forces all rounds
+            enable_dynamic_spawning=True,
+            max_dynamic_agents=2,
+        )
+
+        result = run_felix_workflow(config, provider, "Test task", event_bus=bus)
+
+        # Workflow should complete
+        assert result.synthesis is not None
+        assert result.total_rounds == 3
+
+        # Check if spawn events were emitted (may or may not trigger
+        # depending on confidence, but the machinery ran without error)
+        types = [e.event_type for e in bus.history]
+        assert "workflow.started" in types
+        assert "workflow.completed" in types
+
+    def test_workflow_without_dynamic_spawning(self):
+        """Default config should not spawn — no errors."""
+        provider = _mock_provider()
+        config = WorkflowConfig(max_rounds=1)
+        result = run_felix_workflow(config, provider, "Test task")
+        assert result.synthesis is not None

--- a/tests/unit/test_team_size_optimizer.py
+++ b/tests/unit/test_team_size_optimizer.py
@@ -1,0 +1,56 @@
+"""Tests for TeamSizeOptimizer."""
+
+from __future__ import annotations
+
+from felix_agent_sdk.spawning.optimizer import TeamSizeOptimizer
+
+
+class TestTeamSizeOptimizer:
+    def test_default_for_simple_task(self):
+        opt = TeamSizeOptimizer()
+        size = opt.recommend_team_size("Short task")
+        assert size == 3
+
+    def test_long_task_increases_size(self):
+        opt = TeamSizeOptimizer()
+        short = opt.recommend_team_size("Short")
+        long_task = "x" * 250
+        medium = opt.recommend_team_size(long_task)
+        assert medium > short
+
+    def test_very_long_task(self):
+        opt = TeamSizeOptimizer()
+        size = opt.recommend_team_size("x" * 600)
+        assert size >= 5  # base 3 + 2 length signals
+
+    def test_low_confidence_increases_size(self):
+        opt = TeamSizeOptimizer()
+        results = [{"confidence": 0.3, "content": "weak"} for _ in range(3)]
+        size = opt.recommend_team_size("task", results)
+        assert size > 3
+
+    def test_high_confidence_keeps_base(self):
+        opt = TeamSizeOptimizer()
+        results = [{"confidence": 0.9, "content": "strong"} for _ in range(3)]
+        size = opt.recommend_team_size("Short", results)
+        assert size == 3
+
+    def test_wide_spread_increases_size(self):
+        opt = TeamSizeOptimizer()
+        results = [
+            {"confidence": 0.3, "content": "a"},
+            {"confidence": 0.9, "content": "b"},
+        ]
+        size = opt.recommend_team_size("Short", results)
+        # Low avg (0.6 < 0.7) + spread (0.6 > 0.3) = +2
+        assert size > 3
+
+    def test_respects_max_size(self):
+        opt = TeamSizeOptimizer(max_size=4)
+        size = opt.recommend_team_size("x" * 600, [{"confidence": 0.1, "content": "x"}])
+        assert size <= 4
+
+    def test_respects_min_size(self):
+        opt = TeamSizeOptimizer(min_size=5)
+        size = opt.recommend_team_size("Short")
+        assert size >= 5


### PR DESCRIPTION
## Summary

Fills the `spawning/` stub — the core Felix intelligence feature.

- **ConfidenceMonitor** — tracks per-agent/team confidence, detects stagnation and falling trends, recommends SPAWN/HOLD/PRUNE
- **ContentAnalyzer** — keyword-based topic coverage gap analysis, recommends agent type to fill gaps
- **TeamSizeOptimizer** — heuristic team size from task complexity signals
- **DynamicSpawner** — orchestrates monitor + analyzer per round, emits `spawn.triggered`/`spawn.completed` events
- **WorkflowConfig** — `enable_dynamic_spawning` (default False) and `max_dynamic_agents` (default 3)
- **FelixWorkflow** — replaced `_check_dynamic_spawning()` no-op with inline DynamicSpawner
- **Shared STOPWORDS** — extracted triple-duplicated stopwords from compression.py, task_memory.py, content_analyzer.py into `utils/text.py`

## Test plan
- [x] 35 new tests (monitor, analyzer, optimizer, spawner, workflow integration)
- [x] 772 total tests passing
- [x] `ruff check src/` clean
- [x] 2 new top-level exports: `DynamicSpawner`, `ConfidenceMonitor`
- [x] Stopwords deduplication verified — all 3 consumers pass

Depends on PR #20 (event system). Contributes to Phase 2.