### PR TITLE
feat(cli): add felix console command with init, run, version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ dev = [
     "mkdocs-material>=9.0",
 ]
 
+[project.scripts]
+felix = "felix_agent_sdk.cli.main:main"
+
 [project.urls]
 Homepage = "https://github.com/AppSprout-dev/felix-agent-sdk"
 Documentation = "https://felix-sdk.appsprout.dev"

--- a/src/felix_agent_sdk/cli/__init__.py
+++ b/src/felix_agent_sdk/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Felix CLI — command-line interface for the Felix Agent SDK."""

--- a/src/felix_agent_sdk/cli/init_command.py
+++ b/src/felix_agent_sdk/cli/init_command.py
@@ -1,0 +1,129 @@
+"""``felix init`` — scaffold a new Felix project."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_TEMPLATES = {
+    "research": {
+        "team": [
+            {"type": "research"},
+            {"type": "research"},
+            {"type": "analysis"},
+            {"type": "critic"},
+        ],
+        "helix": "research_heavy",
+        "max_rounds": 4,
+        "confidence_threshold": 0.75,
+    },
+    "analysis": {
+        "team": [
+            {"type": "research"},
+            {"type": "analysis"},
+            {"type": "analysis"},
+            {"type": "critic"},
+        ],
+        "helix": "fast_convergence",
+        "max_rounds": 3,
+        "confidence_threshold": 0.85,
+    },
+    "review": {
+        "team": [
+            {"type": "research"},
+            {"type": "analysis"},
+            {"type": "critic"},
+            {"type": "critic"},
+        ],
+        "helix": "default",
+        "max_rounds": 3,
+        "confidence_threshold": 0.80,
+    },
+}
+
+
+def run_init(name: str, template: str) -> int:
+    """Scaffold a new Felix project directory.
+
+    Creates:
+        name/
+            felix.yaml
+            main.py
+            requirements.txt
+            .env.example
+
+    Returns:
+        Exit code (0 = success, 1 = error).
+    """
+    target = Path(name)
+    if target.exists():
+        print(f"Error: directory '{name}' already exists.", file=sys.stderr)
+        return 1
+
+    if template not in _TEMPLATES:
+        valid = ", ".join(_TEMPLATES)
+        print(f"Error: unknown template '{template}'. Valid: {valid}", file=sys.stderr)
+        return 1
+
+    target.mkdir(parents=True)
+
+    # felix.yaml
+    cfg = _TEMPLATES[template]
+    team_lines = "\n".join(f'  - type: {e["type"]}' for e in cfg["team"])
+    yaml_content = f"""\
+# Felix workflow configuration
+# Run with: felix run felix.yaml
+
+provider: openai
+model: gpt-4o-mini
+
+helix: {cfg["helix"]}
+max_rounds: {cfg["max_rounds"]}
+confidence_threshold: {cfg["confidence_threshold"]}
+
+team:
+{team_lines}
+
+task: "Your research question or task description here"
+"""
+    (target / "felix.yaml").write_text(yaml_content)
+
+    # main.py
+    main_py = """\
+#!/usr/bin/env python3
+\"\"\"Run a Felix workflow programmatically.\"\"\"
+
+from felix_agent_sdk import run_felix_workflow, WorkflowConfig
+from felix_agent_sdk.providers import auto_detect_provider
+
+provider = auto_detect_provider()
+config = WorkflowConfig(max_rounds=3)
+
+result = run_felix_workflow(config, provider, "Your task here")
+print(result.synthesis)
+"""
+    (target / "main.py").write_text(main_py)
+
+    # requirements.txt
+    (target / "requirements.txt").write_text("felix-agent-sdk[openai]\n")
+
+    # .env.example
+    (target / ".env.example").write_text(
+        "# Set your LLM provider API key\n"
+        "# OPENAI_API_KEY=sk-...\n"
+        "# ANTHROPIC_API_KEY=sk-ant-...\n"
+        "FELIX_PROVIDER=openai\n"
+        "FELIX_MODEL=gpt-4o-mini\n"
+    )
+
+    print(f"Created Felix project: {target}/")
+    print(f"  Template: {template}")
+    print(f"  Config:   {target}/felix.yaml")
+    print(f"  Entry:    {target}/main.py")
+    print()
+    print("Next steps:")
+    print(f"  cd {name}")
+    print("  pip install -r requirements.txt")
+    print("  # Copy .env.example to .env and add your API key")
+    print("  felix run felix.yaml")
+    return 0

--- a/src/felix_agent_sdk/cli/main.py
+++ b/src/felix_agent_sdk/cli/main.py
@@ -1,0 +1,65 @@
+"""Felix CLI entry point.
+
+Usage:
+    felix init <name> [--template research|analysis|review]
+    felix run <config.yaml> [--provider NAME] [--verbose]
+    felix version
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``felix`` console command."""
+    parser = argparse.ArgumentParser(
+        prog="felix",
+        description="Felix Agent SDK — helical multi-agent orchestration",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    # --- init ---
+    init_p = subparsers.add_parser("init", help="Scaffold a new Felix project")
+    init_p.add_argument("name", help="Project directory name")
+    init_p.add_argument(
+        "--template", "-t",
+        default="research",
+        choices=["research", "analysis", "review"],
+        help="Workflow template (default: research)",
+    )
+
+    # --- run ---
+    run_p = subparsers.add_parser("run", help="Run a workflow from YAML config")
+    run_p.add_argument("config", help="Path to felix.yaml")
+    run_p.add_argument("--provider", "-p", default=None, help="Override provider name")
+    run_p.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging")
+
+    # --- version ---
+    subparsers.add_parser("version", help="Show SDK version")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "init":
+        from felix_agent_sdk.cli.init_command import run_init
+
+        return run_init(args.name, args.template)
+
+    if args.command == "run":
+        from felix_agent_sdk.cli.run_command import run_workflow
+
+        return run_workflow(args.config, args.provider, args.verbose)
+
+    if args.command == "version":
+        from felix_agent_sdk._version import __version__
+
+        print(f"felix-agent-sdk {__version__}")
+        return 0
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/felix_agent_sdk/cli/run_command.py
+++ b/src/felix_agent_sdk/cli/run_command.py
@@ -1,0 +1,90 @@
+"""``felix run`` — execute a workflow from a YAML config file."""
+
+from __future__ import annotations
+
+import sys
+
+from felix_agent_sdk.cli.yaml_loader import load_workflow_yaml
+from felix_agent_sdk.providers.base import BaseProvider
+from felix_agent_sdk.utils.logging import FelixLogConfig, configure_logging
+from felix_agent_sdk.workflows.runner import run_felix_workflow
+
+
+def run_workflow(config_path: str, provider_name: str | None, verbose: bool) -> int:
+    """Load a YAML config, resolve the provider, and run the workflow.
+
+    Returns:
+        Exit code (0 = success, 1 = error).
+    """
+    if verbose:
+        configure_logging(FelixLogConfig(level="DEBUG"))
+    else:
+        configure_logging(FelixLogConfig(level="WARNING"))
+
+    try:
+        config, task, provider_info = load_workflow_yaml(config_path)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    # Resolve provider
+    effective_provider = provider_name or provider_info.get("provider", "")
+    model = provider_info.get("model", "")
+
+    provider = _resolve_provider(effective_provider, model)
+    if provider is None:
+        print(
+            f"Error: could not create provider '{effective_provider}'. "
+            "Check your API key and provider dependencies.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Running Felix workflow...")
+    print(f"  Provider: {effective_provider or 'auto'}")
+    print(f"  Task: {task[:80]}{'...' if len(task) > 80 else ''}")
+    print(f"  Team: {len(config.team_composition)} agents, {config.max_rounds} rounds")
+    print()
+
+    try:
+        result = run_felix_workflow(config, provider, task)
+    except Exception as e:
+        print(f"Error during workflow: {e}", file=sys.stderr)
+        return 1
+
+    print("=== Result ===")
+    print(f"Rounds: {result.total_rounds}")
+    print(f"Confidence: {result.final_confidence:.3f}")
+    print(f"Converged: {result.metadata.get('converged', False)}")
+    print(f"Tokens: {result.metadata.get('total_tokens', 0)}")
+    print(f"Time: {result.metadata.get('elapsed_seconds', 0)}s")
+    print(f"\nSynthesis:\n{result.synthesis}")
+    return 0
+
+
+def _resolve_provider(name: str, model: str) -> BaseProvider | None:
+    """Try to create a provider by name. Returns None on failure."""
+    if not name or name == "auto":
+        try:
+            from felix_agent_sdk.providers import auto_detect_provider
+
+            return auto_detect_provider()
+        except Exception:
+            return None
+
+    try:
+        if name == "openai":
+            from felix_agent_sdk.providers import OpenAIProvider
+
+            return OpenAIProvider(model=model or "gpt-4o-mini")
+        elif name == "anthropic":
+            from felix_agent_sdk.providers import AnthropicProvider
+
+            return AnthropicProvider(model=model or "claude-sonnet-4-5")
+        elif name == "local":
+            from felix_agent_sdk.providers import LocalProvider
+
+            return LocalProvider(model=model or "default")
+    except Exception:
+        pass
+    return None

--- a/src/felix_agent_sdk/cli/yaml_loader.py
+++ b/src/felix_agent_sdk/cli/yaml_loader.py
@@ -1,0 +1,132 @@
+"""YAML config loader for the Felix CLI.
+
+Parses a ``felix.yaml`` file into a :class:`WorkflowConfig`, a task
+description string, and provider configuration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import yaml
+
+from felix_agent_sdk.core.helix import HelixConfig
+from felix_agent_sdk.workflows.config import SynthesisStrategy, WorkflowConfig
+
+_HELIX_PRESETS = {
+    "default": HelixConfig.default,
+    "research_heavy": HelixConfig.research_heavy,
+    "fast_convergence": HelixConfig.fast_convergence,
+}
+
+
+def load_workflow_yaml(
+    path: str | Path,
+) -> Tuple[WorkflowConfig, str, Dict[str, Any]]:
+    """Parse a ``felix.yaml`` into SDK-native types.
+
+    Args:
+        path: Path to the YAML config file.
+
+    Returns:
+        Tuple of (WorkflowConfig, task_description, provider_info).
+        ``provider_info`` is a dict with keys ``provider`` and ``model``.
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist.
+        ValueError: If required fields are missing or invalid.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Expected a YAML mapping, got {type(raw).__name__}")
+
+    # --- Task (required) ---
+    task = raw.get("task")
+    if not task:
+        raise ValueError("Missing required 'task' field in config")
+
+    # --- Helix ---
+    helix_config = _parse_helix(raw.get("helix", "default"))
+
+    # --- Team composition ---
+    team = _parse_team(raw.get("team"))
+
+    # --- Scalars ---
+    kwargs: Dict[str, Any] = {}
+    if "confidence_threshold" in raw:
+        kwargs["confidence_threshold"] = float(raw["confidence_threshold"])
+    if "max_rounds" in raw:
+        kwargs["max_rounds"] = int(raw["max_rounds"])
+    if "max_agents" in raw:
+        kwargs["max_agents"] = int(raw["max_agents"])
+    if "synthesis_strategy" in raw:
+        kwargs["synthesis_strategy"] = SynthesisStrategy(raw["synthesis_strategy"])
+    if "enable_dynamic_spawning" in raw:
+        kwargs["enable_dynamic_spawning"] = bool(raw["enable_dynamic_spawning"])
+    if "max_dynamic_agents" in raw:
+        kwargs["max_dynamic_agents"] = int(raw["max_dynamic_agents"])
+
+    config = WorkflowConfig(
+        helix_config=helix_config,
+        team_composition=team,
+        **kwargs,
+    )
+
+    # --- Provider info ---
+    provider_info = {
+        "provider": raw.get("provider", ""),
+        "model": raw.get("model", ""),
+    }
+
+    return config, str(task), provider_info
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+
+def _parse_helix(value: Any) -> HelixConfig:
+    """Parse helix field — string preset or dict of params."""
+    if isinstance(value, str):
+        factory = _HELIX_PRESETS.get(value)
+        if factory is None:
+            valid = ", ".join(_HELIX_PRESETS)
+            raise ValueError(f"Unknown helix preset '{value}'. Valid: {valid}")
+        return factory()
+    if isinstance(value, dict):
+        return HelixConfig(
+            top_radius=float(value.get("top_radius", 3.0)),
+            bottom_radius=float(value.get("bottom_radius", 0.5)),
+            height=float(value.get("height", 8.0)),
+            turns=float(value.get("turns", 2.0)),
+        )
+    raise ValueError(f"'helix' must be a preset name or dict, got {type(value).__name__}")
+
+
+def _parse_team(
+    value: Any,
+) -> list[tuple[str, dict[str, Any]]]:
+    """Parse team field — list of {type: ...} dicts."""
+    if value is None:
+        return [("research", {}), ("analysis", {}), ("critic", {})]
+    if not isinstance(value, list):
+        raise ValueError(f"'team' must be a list, got {type(value).__name__}")
+
+    result: list[tuple[str, dict[str, Any]]] = []
+    for entry in value:
+        if isinstance(entry, str):
+            result.append((entry, {}))
+        elif isinstance(entry, dict):
+            agent_type = entry.pop("type", "llm")
+            result.append((str(agent_type), dict(entry)))
+        else:
+            raise ValueError(f"Team entry must be a string or dict, got {type(entry).__name__}")
+    return result

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,208 @@
+"""Tests for the Felix CLI — init, run, yaml_loader, and version."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from felix_agent_sdk.cli.init_command import run_init
+from felix_agent_sdk.cli.main import main
+from felix_agent_sdk.cli.yaml_loader import load_workflow_yaml
+from felix_agent_sdk.core.helix import HelixConfig
+from felix_agent_sdk.workflows.config import SynthesisStrategy
+
+
+# ---------------------------------------------------------------------------
+# felix version
+# ---------------------------------------------------------------------------
+
+
+class TestVersion:
+    def test_version_command(self, capsys):
+        code = main(["version"])
+        assert code == 0
+        output = capsys.readouterr().out
+        assert "felix-agent-sdk" in output
+
+    def test_no_command_shows_help(self, capsys):
+        code = main([])
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# felix init
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_scaffolds_project(self, tmp_path):
+        target = tmp_path / "myproject"
+        code = run_init(str(target), "research")
+        assert code == 0
+        assert (target / "felix.yaml").exists()
+        assert (target / "main.py").exists()
+        assert (target / "requirements.txt").exists()
+        assert (target / ".env.example").exists()
+
+    def test_yaml_is_valid(self, tmp_path):
+        target = tmp_path / "test_yaml"
+        run_init(str(target), "research")
+        with open(target / "felix.yaml") as f:
+            data = yaml.safe_load(f)
+        assert data["helix"] == "research_heavy"
+        assert data["task"] is not None
+        assert len(data["team"]) == 4
+
+    def test_analysis_template(self, tmp_path):
+        target = tmp_path / "analysis_proj"
+        code = run_init(str(target), "analysis")
+        assert code == 0
+        with open(target / "felix.yaml") as f:
+            data = yaml.safe_load(f)
+        assert data["helix"] == "fast_convergence"
+
+    def test_review_template(self, tmp_path):
+        target = tmp_path / "review_proj"
+        code = run_init(str(target), "review")
+        assert code == 0
+        with open(target / "felix.yaml") as f:
+            data = yaml.safe_load(f)
+        assert data["helix"] == "default"
+
+    def test_existing_directory_fails(self, tmp_path):
+        target = tmp_path / "existing"
+        target.mkdir()
+        code = run_init(str(target), "research")
+        assert code == 1
+
+    def test_unknown_template_fails(self, tmp_path):
+        code = run_init(str(tmp_path / "bad"), "nonexistent")
+        assert code == 1
+
+    def test_via_main(self, tmp_path, capsys):
+        target = tmp_path / "cli_init"
+        code = main(["init", str(target)])
+        assert code == 0
+        assert (target / "felix.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# yaml_loader
+# ---------------------------------------------------------------------------
+
+
+class TestYamlLoader:
+    def _write_yaml(self, tmp_path: Path, data: dict) -> Path:
+        p = tmp_path / "felix.yaml"
+        with open(p, "w") as f:
+            yaml.dump(data, f)
+        return p
+
+    def test_minimal_config(self, tmp_path):
+        path = self._write_yaml(tmp_path, {"task": "Test question"})
+        config, task, provider_info = load_workflow_yaml(path)
+        assert task == "Test question"
+        assert len(config.team_composition) == 3  # default team
+        assert config.max_rounds == 3
+
+    def test_helix_preset(self, tmp_path):
+        path = self._write_yaml(tmp_path, {
+            "task": "Test",
+            "helix": "research_heavy",
+        })
+        config, _, _ = load_workflow_yaml(path)
+        expected = HelixConfig.research_heavy()
+        assert config.helix_config.top_radius == expected.top_radius
+
+    def test_helix_dict(self, tmp_path):
+        path = self._write_yaml(tmp_path, {
+            "task": "Test",
+            "helix": {"top_radius": 5.0, "bottom_radius": 0.1},
+        })
+        config, _, _ = load_workflow_yaml(path)
+        assert config.helix_config.top_radius == 5.0
+        assert config.helix_config.bottom_radius == 0.1
+
+    def test_team_parsing(self, tmp_path):
+        path = self._write_yaml(tmp_path, {
+            "task": "Test",
+            "team": [
+                {"type": "research"},
+                {"type": "analysis"},
+                {"type": "critic"},
+                {"type": "critic"},
+            ],
+        })
+        config, _, _ = load_workflow_yaml(path)
+        assert len(config.team_composition) == 4
+        types = [t for t, _ in config.team_composition]
+        assert types == ["research", "analysis", "critic", "critic"]
+
+    def test_scalars(self, tmp_path):
+        path = self._write_yaml(tmp_path, {
+            "task": "Test",
+            "max_rounds": 5,
+            "confidence_threshold": 0.9,
+            "max_agents": 15,
+            "synthesis_strategy": "best_result",
+            "enable_dynamic_spawning": True,
+            "max_dynamic_agents": 5,
+        })
+        config, _, _ = load_workflow_yaml(path)
+        assert config.max_rounds == 5
+        assert config.confidence_threshold == 0.9
+        assert config.max_agents == 15
+        assert config.synthesis_strategy == SynthesisStrategy.BEST_RESULT
+        assert config.enable_dynamic_spawning is True
+        assert config.max_dynamic_agents == 5
+
+    def test_provider_info(self, tmp_path):
+        path = self._write_yaml(tmp_path, {
+            "task": "Test",
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-5",
+        })
+        _, _, info = load_workflow_yaml(path)
+        assert info["provider"] == "anthropic"
+        assert info["model"] == "claude-sonnet-4-5"
+
+    def test_missing_task_raises(self, tmp_path):
+        path = self._write_yaml(tmp_path, {"helix": "default"})
+        with pytest.raises(ValueError, match="Missing required 'task'"):
+            load_workflow_yaml(path)
+
+    def test_missing_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_workflow_yaml("/nonexistent/felix.yaml")
+
+    def test_invalid_helix_preset_raises(self, tmp_path):
+        path = self._write_yaml(tmp_path, {"task": "T", "helix": "bogus"})
+        with pytest.raises(ValueError, match="Unknown helix preset"):
+            load_workflow_yaml(path)
+
+    def test_string_team_entries(self, tmp_path):
+        path = self._write_yaml(tmp_path, {
+            "task": "Test",
+            "team": ["research", "analysis"],
+        })
+        config, _, _ = load_workflow_yaml(path)
+        assert config.team_composition == [("research", {}), ("analysis", {})]
+
+
+# ---------------------------------------------------------------------------
+# felix init → felix run round-trip (scaffolded yaml is loadable)
+# ---------------------------------------------------------------------------
+
+
+class TestInitRunRoundTrip:
+    def test_scaffolded_yaml_is_loadable(self, tmp_path):
+        target = tmp_path / "roundtrip"
+        run_init(str(target), "research")
+        config, task, info = load_workflow_yaml(target / "felix.yaml")
+        assert task is not None
+        assert len(config.team_composition) > 0
+        assert info["provider"] == "openai"


### PR DESCRIPTION
## Summary

Adds the `felix` CLI as a console script entry point.

- **`felix init <name> [--template]`** — scaffolds project dir with `felix.yaml`, `main.py`, `requirements.txt`, `.env.example`. Templates: research, analysis, review.
- **`felix run <config.yaml> [--provider] [--verbose]`** — loads YAML, resolves provider, runs workflow, prints result.
- **`felix version`** — prints SDK version.
- **yaml_loader** — parses helix presets or custom dicts, team composition, all WorkflowConfig scalars including dynamic spawning fields.
- Console script: `[project.scripts] felix = "felix_agent_sdk.cli.main:main"`

## Test plan
- [x] 20 new tests (init scaffolding, yaml parsing, version, round-trip)
- [x] 792 total tests passing
- [x] `ruff check src/` clean
- [x] `felix version` prints version after `pip install -e .`
- [x] `felix init myproject --template analysis` creates valid project
- [x] Scaffolded `felix.yaml` round-trips through `load_workflow_yaml()`

Depends on PRs #20, #22 (logging), #24 (spawning config). Contributes to Phase 2.